### PR TITLE
Spike/include top stack frame when inspecting spy call

### DIFF
--- a/documentation/assertions/spy/threw.md
+++ b/documentation/assertions/spy/threw.md
@@ -50,8 +50,8 @@ expect(stub, 'always threw', /waat/);
 expected stub always threw /waat/
 
 invocations(
-  stub(), // expected stub() threw /waat/
-          //   expected TypeError('wat') to satisfy /waat/
-  stub()
+  stub() at theFunction (theFileName:xx:yy), // expected stub() at theFunction (theFileName:xx:yy) threw /waat/
+                                             //   expected TypeError('wat') to satisfy /waat/
+  stub() at theFunction (theFileName:xx:yy)
 )
 ```

--- a/documentation/assertions/spy/threw.md
+++ b/documentation/assertions/spy/threw.md
@@ -50,7 +50,7 @@ expect(stub, 'always threw', /waat/);
 expected stub always threw /waat/
 
 invocations(
-  stub() at theFunction (theFileName:xx:yy), // expected stub() at theFunction (theFileName:xx:yy) threw /waat/
+  stub() at theFunction (theFileName:xx:yy), // expected: threw /waat/
                                              //   expected TypeError('wat') to satisfy /waat/
   stub() at theFunction (theFileName:xx:yy)
 )

--- a/documentation/assertions/spy/was-called-on.md
+++ b/documentation/assertions/spy/was-called-on.md
@@ -17,8 +17,8 @@ expect(obj.spy, 'was called on', another);
 expected spy was called on {}
 
 invocations(
-  spy() // expected spy() was called on {}
-        //   expected spy to be called with {} as this but was called with { spy: spy }
+  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) was called on {}
+                                           //   expected spy to be called with {} as this but was called with { spy: spy }
 )
 ```
 
@@ -41,8 +41,8 @@ expect(obj.spy, 'was always called on', obj);
 expected spy was always called on { spy: spy }
 
 invocations(
-  spy(),
-  spy() // expected spy() was called on { spy: spy }
-        //   expected spy to be called with { spy: spy } as this but was called with {}
+  spy() at theFunction (theFileName:xx:yy),
+  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) was called on { spy: spy }
+                                           //   expected spy to be called with { spy: spy } as this but was called with {}
 )
 ```

--- a/documentation/assertions/spy/was-called-on.md
+++ b/documentation/assertions/spy/was-called-on.md
@@ -17,7 +17,7 @@ expect(obj.spy, 'was called on', another);
 expected spy was called on {}
 
 invocations(
-  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) was called on {}
+  spy() at theFunction (theFileName:xx:yy) // expected: was called on {}
                                            //   expected spy to be called with {} as this but was called with { spy: spy }
 )
 ```
@@ -42,7 +42,7 @@ expected spy was always called on { spy: spy }
 
 invocations(
   spy() at theFunction (theFileName:xx:yy),
-  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) was called on { spy: spy }
+  spy() at theFunction (theFileName:xx:yy) // expected: was called on { spy: spy }
                                            //   expected spy to be called with { spy: spy } as this but was called with {}
 )
 ```

--- a/documentation/assertions/spy/was-called-times.md
+++ b/documentation/assertions/spy/was-called-times.md
@@ -21,7 +21,13 @@ expect(add, 'was called times', 2);
 
 ```output
 expected spy was called times 2
-  expected invocations( spy( 41, 42 ), spy( 41, 43 ), spy( 41, 44 ), spy( 41, 45 ) )
+  expected
+  invocations(
+    spy( 41, 42 ) at theFunction (theFileName:xx:yy),
+    spy( 41, 43 ) at theFunction (theFileName:xx:yy),
+    spy( 41, 44 ) at theFunction (theFileName:xx:yy),
+    spy( 41, 45 ) at theFunction (theFileName:xx:yy)
+  )
   to have length 2
     expected 4 to be 2
 ```

--- a/documentation/assertions/spy/was-called-with.md
+++ b/documentation/assertions/spy/was-called-with.md
@@ -21,7 +21,7 @@ invocations(
     'baz', // should equal { foo: 'bar' }
     'qux',
     'quux'
-  )
+  ) at theFunction (theFileName:xx:yy)
 )
 ```
 
@@ -47,13 +47,13 @@ expected spy
 was always called with { foo: 'bar' }, 'baz', expect.it('to be truthy')
 
 invocations(
-  spy( { foo: 'bar' }, 'baz', 'qux', 'quux' ),
-  spy( { foo: 'bar' }, 'baz', 'qux', 'quux' ),
+  spy( { foo: 'bar' }, 'baz', 'qux', 'quux' ) at theFunction (theFileName:xx:yy),
+  spy( { foo: 'bar' }, 'baz', 'qux', 'quux' ) at theFunction (theFileName:xx:yy),
   spy(
     { foo: 'bar' },
     'baz',
     undefined // expected undefined to be truthy
-  )
+  ) at theFunction (theFileName:xx:yy)
 )
 ```
 
@@ -82,7 +82,7 @@ invocations(
     'baz',
     'qux',
     'quux' // should be removed
-  )
+  ) at theFunction (theFileName:xx:yy)
 )
 ```
 
@@ -109,12 +109,12 @@ expected spy
 was always called with exactly { foo: 'bar' }, 'baz', expect.it('to be truthy')
 
 invocations(
-  spy( { foo: 'bar' }, 'baz', 'qux' ),
-  spy( { foo: 'bar' }, 'baz', 'qux' ),
+  spy( { foo: 'bar' }, 'baz', 'qux' ) at theFunction (theFileName:xx:yy),
+  spy( { foo: 'bar' }, 'baz', 'qux' ) at theFunction (theFileName:xx:yy),
   spy(
     { foo: 'bar' },
     'baz',
     // expected undefined to be truthy
-  )
+  ) at theFunction (theFileName:xx:yy)
 )
 ```

--- a/documentation/assertions/spy/was-called.md
+++ b/documentation/assertions/spy/was-called.md
@@ -34,6 +34,6 @@ expect(add, 'was not called');
 expected spy was not called
 
 invocations(
-  spy( 42, 42 ) // should be removed
+  spy( 42, 42 ) at theFunction (theFileName:xx:yy) // should be removed
 )
 ```

--- a/generate-site.js
+++ b/generate-site.js
@@ -5,5 +5,8 @@ sinon = require('sinon');
 var unexpected = require('unexpected');
 unexpected.installPlugin(require('./lib/unexpected-sinon'));
 var generator = require('unexpected-documentation-site-generator');
+
+require('./test/monkeyPatchSinonStackFrames')(sinon);
+
 argv.unexpected = unexpected;
 generator(argv);

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -143,17 +143,18 @@
                 prefix: function (output, value) {
                     return output.jsFunctionName(value.proxy.displayName).text('(');
                 },
-                suffix: function (output) {
-                    return output.text(')');
+                suffix: function (output, value) {
+                    output.text(')');
+                    if (value.getStackFrames) {
+                        var topStackFrame = makePathsRelativeToCwdOrLocation(value.getStackFrames()[0].replace(/^\s*(?:at\s+|@)?/, ''));
+                        output.sp().gray('at ' + topStackFrame);
+                    }
+                    return output;
                 },
                 inspect: function (value, depth, output, inspect) {
                     this.prefix(output, value);
                     output.append(inspect(toSpyArguments(value.args), depth + 1));
                     this.suffix(output, value);
-                    if (value.getStackFrames) {
-                        var topStackFrame = makePathsRelativeToCwdOrLocation(value.getStackFrames()[0].replace(/^\s*(?:at\s+|@)?/, ''));
-                        output.sp().gray('at ' + topStackFrame);
-                    }
                 },
                 equal: function (actual, expected, equal) {
                     return equal(actual.args, expected.args);

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -1,3 +1,4 @@
+/*global location*/
 // Copyright (c) 2013 Sune Simonsen <sune@we-knowhow.dk>
 //
 // Permission is hereby granted, free of charge, to any person

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -91,6 +91,25 @@
         }
     }
 
+    function escapeRegExpMetaChars(str) {
+        return str.replace(/[$.^()[\]{}]/g, '\\$&');
+    }
+
+    var cwdOrLocationRegExp;
+    if (typeof location === 'object' && typeof location.href === 'string') {
+        cwdOrLocationRegExp = new RegExp(escapeRegExpMetaChars(location.href.replace(/[^/]+(?:\?[^#]*)?(?:#.*)?$/, '') + '/'));
+    } else if (typeof require === 'function' && typeof module === 'object' && typeof module.exports === 'object' && typeof process === 'object') {
+        cwdOrLocationRegExp = new RegExp(escapeRegExpMetaChars(process.cwd() + '/'));
+    }
+
+    function makePathsRelativeToCwdOrLocation(str) {
+        if (cwdOrLocationRegExp) {
+            return str.replace(cwdOrLocationRegExp, '');
+        } else {
+            return str;
+        }
+    }
+
     return {
         name: 'unexpected-sinon',
         installInto: function (expect) {
@@ -131,6 +150,10 @@
                     this.prefix(output, value);
                     output.append(inspect(toSpyArguments(value.args), depth + 1));
                     this.suffix(output, value);
+                    if (value.getStackFrames) {
+                        var topStackFrame = makePathsRelativeToCwdOrLocation(value.getStackFrames()[0].replace(/^\s*(?:at\s+|@)?/, ''));
+                        output.sp().gray('at ' + topStackFrame);
+                    }
                 },
                 equal: function (actual, expected, equal) {
                     return equal(actual.args, expected.args);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "main": "./lib/unexpected-sinon.js",
   "peerDependencies": {
     "sinon": "*",
-    "unexpected": "^9.8.0"
+    "unexpected": "^9.8.1"
   },
   "devDependencies": {
     "coveralls": "2.11.3",
@@ -38,7 +38,7 @@
     "mocha": "2.2.5",
     "serve": "*",
     "sinon": "1.16.1",
-    "unexpected": "9.8.0",
+    "unexpected": "9.8.1",
     "unexpected-documentation-site-generator": "2.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "main": "./lib/unexpected-sinon.js",
   "peerDependencies": {
     "sinon": "*",
-    "unexpected": "^9.7.0"
+    "unexpected": "^9.8.0"
   },
   "devDependencies": {
     "coveralls": "2.11.3",
@@ -38,7 +38,7 @@
     "mocha": "2.2.5",
     "serve": "*",
     "sinon": "1.16.1",
-    "unexpected": "9.7.0",
+    "unexpected": "9.8.0",
     "unexpected-documentation-site-generator": "2.5.2"
   }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -3,3 +3,5 @@ sinon = require('sinon');
 unexpected = require('unexpected').clone();
 unexpectedSinon = require('../lib/unexpected-sinon');
 unexpected.installPlugin(unexpectedSinon);
+
+require('./monkeyPatchSinonStackFrames')(sinon);

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -95,7 +95,7 @@ describe("documentation tests", function () {
                 "expected stub always threw /waat/\n" +
                 "\n" +
                 "invocations(\n" +
-                "  stub() at theFunction (theFileName:xx:yy), // expected stub() at theFunction (theFileName:xx:yy) threw /waat/\n" +
+                "  stub() at theFunction (theFileName:xx:yy), // expected: threw /waat/\n" +
                 "                                             //   expected TypeError('wat') to satisfy /waat/\n" +
                 "  stub() at theFunction (theFileName:xx:yy)\n" +
                 ")"
@@ -124,7 +124,7 @@ describe("documentation tests", function () {
                 "expected spy was called on {}\n" +
                 "\n" +
                 "invocations(\n" +
-                "  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) was called on {}\n" +
+                "  spy() at theFunction (theFileName:xx:yy) // expected: was called on {}\n" +
                 "                                           //   expected spy to be called with {} as this but was called with { spy: spy }\n" +
                 ")"
             );
@@ -147,7 +147,7 @@ describe("documentation tests", function () {
                 "\n" +
                 "invocations(\n" +
                 "  spy() at theFunction (theFileName:xx:yy),\n" +
-                "  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) was called on { spy: spy }\n" +
+                "  spy() at theFunction (theFileName:xx:yy) // expected: was called on { spy: spy }\n" +
                 "                                           //   expected spy to be called with { spy: spy } as this but was called with {}\n" +
                 ")"
             );

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -95,9 +95,9 @@ describe("documentation tests", function () {
                 "expected stub always threw /waat/\n" +
                 "\n" +
                 "invocations(\n" +
-                "  stub(), // expected stub() threw /waat/\n" +
-                "          //   expected TypeError('wat') to satisfy /waat/\n" +
-                "  stub()\n" +
+                "  stub() at theFunction (theFileName:xx:yy), // expected stub() at theFunction (theFileName:xx:yy) threw /waat/\n" +
+                "                                             //   expected TypeError('wat') to satisfy /waat/\n" +
+                "  stub() at theFunction (theFileName:xx:yy)\n" +
                 ")"
             );
         }
@@ -124,8 +124,8 @@ describe("documentation tests", function () {
                 "expected spy was called on {}\n" +
                 "\n" +
                 "invocations(\n" +
-                "  spy() // expected spy() was called on {}\n" +
-                "        //   expected spy to be called with {} as this but was called with { spy: spy }\n" +
+                "  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) was called on {}\n" +
+                "                                           //   expected spy to be called with {} as this but was called with { spy: spy }\n" +
                 ")"
             );
         }
@@ -146,9 +146,9 @@ describe("documentation tests", function () {
                 "expected spy was always called on { spy: spy }\n" +
                 "\n" +
                 "invocations(\n" +
-                "  spy(),\n" +
-                "  spy() // expected spy() was called on { spy: spy }\n" +
-                "        //   expected spy to be called with { spy: spy } as this but was called with {}\n" +
+                "  spy() at theFunction (theFileName:xx:yy),\n" +
+                "  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) was called on { spy: spy }\n" +
+                "                                           //   expected spy to be called with { spy: spy } as this but was called with {}\n" +
                 ")"
             );
         }
@@ -183,7 +183,13 @@ describe("documentation tests", function () {
         } catch (e) {
             expect(e, "to have message",
                 "expected spy was called times 2\n" +
-                "  expected invocations( spy( 41, 42 ), spy( 41, 43 ), spy( 41, 44 ), spy( 41, 45 ) )\n" +
+                "  expected\n" +
+                "  invocations(\n" +
+                "    spy( 41, 42 ) at theFunction (theFileName:xx:yy),\n" +
+                "    spy( 41, 43 ) at theFunction (theFileName:xx:yy),\n" +
+                "    spy( 41, 44 ) at theFunction (theFileName:xx:yy),\n" +
+                "    spy( 41, 45 ) at theFunction (theFileName:xx:yy)\n" +
+                "  )\n" +
                 "  to have length 2\n" +
                 "    expected 4 to be 2"
             );
@@ -222,7 +228,7 @@ describe("documentation tests", function () {
                 "    'baz', // should equal { foo: 'bar' }\n" +
                 "    'qux',\n" +
                 "    'quux'\n" +
-                "  )\n" +
+                "  ) at theFunction (theFileName:xx:yy)\n" +
                 ")"
             );
         }
@@ -247,13 +253,13 @@ describe("documentation tests", function () {
                 "was always called with { foo: 'bar' }, 'baz', expect.it('to be truthy')\n" +
                 "\n" +
                 "invocations(\n" +
-                "  spy( { foo: 'bar' }, 'baz', 'qux', 'quux' ),\n" +
-                "  spy( { foo: 'bar' }, 'baz', 'qux', 'quux' ),\n" +
+                "  spy( { foo: 'bar' }, 'baz', 'qux', 'quux' ) at theFunction (theFileName:xx:yy),\n" +
+                "  spy( { foo: 'bar' }, 'baz', 'qux', 'quux' ) at theFunction (theFileName:xx:yy),\n" +
                 "  spy(\n" +
                 "    { foo: 'bar' },\n" +
                 "    'baz',\n" +
                 "    undefined // expected undefined to be truthy\n" +
-                "  )\n" +
+                "  ) at theFunction (theFileName:xx:yy)\n" +
                 ")"
             );
         }
@@ -280,7 +286,7 @@ describe("documentation tests", function () {
                 "    'baz',\n" +
                 "    'qux',\n" +
                 "    'quux' // should be removed\n" +
-                "  )\n" +
+                "  ) at theFunction (theFileName:xx:yy)\n" +
                 ")"
             );
         }
@@ -305,13 +311,13 @@ describe("documentation tests", function () {
                 "was always called with exactly { foo: 'bar' }, 'baz', expect.it('to be truthy')\n" +
                 "\n" +
                 "invocations(\n" +
-                "  spy( { foo: 'bar' }, 'baz', 'qux' ),\n" +
-                "  spy( { foo: 'bar' }, 'baz', 'qux' ),\n" +
+                "  spy( { foo: 'bar' }, 'baz', 'qux' ) at theFunction (theFileName:xx:yy),\n" +
+                "  spy( { foo: 'bar' }, 'baz', 'qux' ) at theFunction (theFileName:xx:yy),\n" +
                 "  spy(\n" +
                 "    { foo: 'bar' },\n" +
                 "    'baz',\n" +
                 "    // expected undefined to be truthy\n" +
-                "  )\n" +
+                "  ) at theFunction (theFileName:xx:yy)\n" +
                 ")"
             );
         }
@@ -355,7 +361,7 @@ describe("documentation tests", function () {
                 "expected spy was not called\n" +
                 "\n" +
                 "invocations(\n" +
-                "  spy( 42, 42 ) // should be removed\n" +
+                "  spy( 42, 42 ) at theFunction (theFileName:xx:yy) // should be removed\n" +
                 ")"
             );
         }

--- a/test/monkeyPatchSinonStackFrames.js
+++ b/test/monkeyPatchSinonStackFrames.js
@@ -1,0 +1,17 @@
+// Monkey-patch sinon.create to patch all created spyCall instances
+// so that the top stack frame is a predictable string.
+// Prevents every test from failing when the test suite is updated.
+module.exports = function (sinon) {
+    var sinonCreate = sinon.create;
+    sinon.create = function (arg) {
+        var getStackFrames = arg.getStackFrames;
+        if (getStackFrames) {
+            arg.getStackFrames = function () {
+                var stackFrames = getStackFrames.call(this);
+                stackFrames[0] = 'at theFunction (theFileName:xx:yy)';
+                return stackFrames;
+            };
+        }
+        return sinonCreate.call(this, arg);
+    };
+};

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -1,6 +1,7 @@
 /*global describe, it, beforeEach, sinon, unexpected*/
 describe('unexpected-sinon', function () {
     var expect, spy;
+
     beforeEach(function () {
         expect = unexpected.clone();
         expect.output.preferredWidth = 120;
@@ -35,8 +36,8 @@ describe('unexpected-sinon', function () {
                 "expected spy was not called\n" +
                 "\n" +
                 "invocations(\n" +
-                "  spy( 42, { foo: 'bar' } ), // should be removed\n" +
-                "  spy( 'baz' ) // should be removed\n" +
+                "  spy( 42, { foo: 'bar' } ) at theFunction (theFileName:xx:yy), // should be removed\n" +
+                "  spy( 'baz' ) at theFunction (theFileName:xx:yy) // should be removed\n" +
                 ")"
             );
         });
@@ -59,7 +60,8 @@ describe('unexpected-sinon', function () {
                 expect(spy, "was called once");
             }, "to throw exception",
                    "expected spy was called once\n" +
-                   "  expected invocations( spy( 42, { foo: \'bar\' } ), spy( \'baz\' ) ) to have length 1\n" +
+                   "  expected invocations( spy( 42, { foo: \'bar\' } ) at theFunction (theFileName:xx:yy), spy( \'baz\' ) at theFunction (theFileName:xx:yy) )\n" +
+                   "  to have length 1\n" +
                    "    expected 2 to be 1");
         });
     });
@@ -80,7 +82,7 @@ describe('unexpected-sinon', function () {
                 spy();
                 expect(spy, "was called twice");
             }, "to throw exception", "expected spy was called twice\n" +
-                   "  expected invocations( spy() ) to have length 2\n" +
+                   "  expected invocations( spy() at theFunction (theFileName:xx:yy) ) to have length 2\n" +
                    "    expected 1 to be 2");
 
             expect(function () {
@@ -89,7 +91,13 @@ describe('unexpected-sinon', function () {
                 expect(spy, "was called twice");
             }, "to throw exception",
                    "expected spy was called twice\n" +
-                   "  expected invocations( spy(), spy( 42 ), spy() ) to have length 2\n" +
+                   "  expected\n" +
+                   "  invocations(\n" +
+                   "    spy() at theFunction (theFileName:xx:yy),\n" +
+                   "    spy( 42 ) at theFunction (theFileName:xx:yy),\n" +
+                   "    spy() at theFunction (theFileName:xx:yy)\n" +
+                   "  )\n" +
+                   "  to have length 2\n" +
                    "    expected 3 to be 2");
         });
     });
@@ -107,7 +115,7 @@ describe('unexpected-sinon', function () {
                 expect(spy, "was called thrice");
             }, "to throw exception",
                    "expected spy was called thrice\n" +
-                   "  expected invocations( spy(), spy() ) to have length 3\n" +
+                   "  expected invocations( spy() at theFunction (theFileName:xx:yy), spy() at theFunction (theFileName:xx:yy) ) to have length 3\n" +
                    "    expected 2 to be 3");
 
             expect(function () {
@@ -116,7 +124,14 @@ describe('unexpected-sinon', function () {
                 expect(spy, "was called thrice");
             }, "to throw exception",
                    "expected spy was called thrice\n" +
-                   "  expected invocations( spy(), spy(), spy(), spy() ) to have length 3\n" +
+                   "  expected\n" +
+                   "  invocations(\n" +
+                   "    spy() at theFunction (theFileName:xx:yy),\n" +
+                   "    spy() at theFunction (theFileName:xx:yy),\n" +
+                   "    spy() at theFunction (theFileName:xx:yy),\n" +
+                   "    spy() at theFunction (theFileName:xx:yy)\n" +
+                   "  )\n" +
+                   "  to have length 3\n" +
                    "    expected 4 to be 3");
         });
     });
@@ -135,7 +150,7 @@ describe('unexpected-sinon', function () {
                 expect(spy, "was called times", 3);
             }, "to throw exception",
                    "expected spy was called times 3\n" +
-                   "  expected invocations( spy(), spy() ) to have length 3\n" +
+                   "  expected invocations( spy() at theFunction (theFileName:xx:yy), spy() at theFunction (theFileName:xx:yy) ) to have length 3\n" +
                    "    expected 2 to be 3");
 
             expect(function () {
@@ -144,7 +159,14 @@ describe('unexpected-sinon', function () {
                 expect(spy, "was called times", 3);
             }, "to throw exception",
                    "expected spy was called times 3\n" +
-                   "  expected invocations( spy(), spy(), spy(), spy() ) to have length 3\n" +
+                   "  expected\n" +
+                   "  invocations(\n" +
+                   "    spy() at theFunction (theFileName:xx:yy),\n" +
+                   "    spy() at theFunction (theFileName:xx:yy),\n" +
+                   "    spy() at theFunction (theFileName:xx:yy),\n" +
+                   "    spy() at theFunction (theFileName:xx:yy)\n" +
+                   "  )\n" +
+                   "  to have length 3\n" +
                    "    expected 4 to be 3");
         });
     });
@@ -239,9 +261,9 @@ describe('unexpected-sinon', function () {
                    "expected spy was always called on { spy: spy }\n" +
                    "\n" +
                    "invocations(\n" +
-                   "  spy(),\n" +
-                   "  spy() // expected spy() was called on { spy: spy }\n" +
-                   "        //   expected spy to be called with { spy: spy } as this but was called with null\n" +
+                   "  spy() at theFunction (theFileName:xx:yy),\n" +
+                   "  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) was called on { spy: spy }\n" +
+                   "                                           //   expected spy to be called with { spy: spy } as this but was called with null\n" +
                    ")");
         });
     });
@@ -277,7 +299,7 @@ describe('unexpected-sinon', function () {
                    "    'baz',\n" +
                    "    true,\n" +
                    "    false\n" +
-                   "  )\n" +
+                   "  ) at theFunction (theFileName:xx:yy)\n" +
                    ")");
         });
     });
@@ -301,9 +323,10 @@ describe('unexpected-sinon', function () {
                    "  spy(\n" +
                    "    'something else', // should equal { foo: 'bar' }\n" +
                    "    undefined, // should equal 'baz'\n" +
-                   "    undefined // expected spy( 'something else' ) to satisfy { 0: { foo: 'bar' }, 1: 'baz', 2: match(truthy) }\n" +
-                   "  ),\n" +
-                   "  spy( { foo: 'bar' }, 'baz', true, false )\n" +
+                   "    undefined // expected spy( 'something else' ) at theFunction (theFileName:xx:yy)\n" +
+                   "              // to satisfy { 0: { foo: 'bar' }, 1: 'baz', 2: match(truthy) }\n" +
+                   "  ) at theFunction (theFileName:xx:yy),\n" +
+                   "  spy( { foo: 'bar' }, 'baz', true, false ) at theFunction (theFileName:xx:yy)\n" +
                    ")");
         });
     });
@@ -322,7 +345,7 @@ describe('unexpected-sinon', function () {
                    "expected spy was never called with 'bar', match(truthy)\n" +
                    "\n" +
                    "invocations(\n" +
-                   "  spy( 'bar', 'true' ) // expected spy( 'bar', 'true' ) not to satisfy { 0: 'bar', 1: match(truthy) }\n" +
+                   "  spy( 'bar', 'true' ) at theFunction (theFileName:xx:yy) // expected spy( 'bar', 'true' ) at theFunction (theFileName:xx:yy) not to satisfy { 0: 'bar', 1: match(truthy) }\n" +
                    ")");
         });
 
@@ -335,8 +358,8 @@ describe('unexpected-sinon', function () {
                    "expected spy was never called with 'bar'\n" +
                    "\n" +
                    "invocations(\n" +
-                   "  spy( 'foo' ),\n" +
-                   "  spy( 'bar', {} ) // expected spy( 'bar', {} ) not to satisfy { 0: 'bar' }\n" +
+                   "  spy( 'foo' ) at theFunction (theFileName:xx:yy),\n" +
+                   "  spy( 'bar', {} ) at theFunction (theFileName:xx:yy) // expected spy( 'bar', {} ) at theFunction (theFileName:xx:yy) not to satisfy { 0: 'bar' }\n" +
                    ")");
         });
     });
@@ -361,7 +384,7 @@ describe('unexpected-sinon', function () {
                    "    'bar',\n" +
                    "    'baz',\n" +
                    "    'qux' // should be removed\n" +
-                   "  )\n" +
+                   "  ) at theFunction (theFileName:xx:yy)\n" +
                    ")");
         });
     });
@@ -382,13 +405,13 @@ describe('unexpected-sinon', function () {
                    "expected spy was always called with exactly 'foo', 'bar', match(truthy)\n" +
                    "\n" +
                    "invocations(\n" +
-                   "  spy( 'foo', 'bar', 'baz' ),\n" +
+                   "  spy( 'foo', 'bar', 'baz' ) at theFunction (theFileName:xx:yy),\n" +
                    "  spy(\n" +
                    "    'foo',\n" +
                    "    'bar',\n" +
                    "    'baz',\n" +
                    "    'qux' // should be removed\n" +
-                   "  )\n" +
+                   "  ) at theFunction (theFileName:xx:yy)\n" +
                    ")");
         });
     });
@@ -427,15 +450,15 @@ describe('unexpected-sinon', function () {
                        "expected stub threw { name: 'TypeError' }\n" +
                        "\n" +
                        "invocations(\n" +
-                       "  stub() // expected stub() threw { name: 'TypeError' }\n" +
-                       "         //   expected Error() to satisfy { name: 'TypeError' }\n" +
-                       "         //\n" +
-                       "         //   {\n" +
-                       "         //     message: '',\n" +
-                       "         //     name: 'Error' // should equal 'TypeError'\n" +
-                       "         //                   // -Error\n" +
-                       "         //                   // +TypeError\n" +
-                       "         //   }\n" +
+                       "  stub() at theFunction (theFileName:xx:yy) // expected stub() at theFunction (theFileName:xx:yy) threw { name: 'TypeError' }\n" +
+                       "                                            //   expected Error() to satisfy { name: 'TypeError' }\n" +
+                       "                                            //\n" +
+                       "                                            //   {\n" +
+                       "                                            //     message: '',\n" +
+                       "                                            //     name: 'Error' // should equal 'TypeError'\n" +
+                       "                                            //                   // -Error\n" +
+                       "                                            //                   // +TypeError\n" +
+                       "                                            //   }\n" +
                        ")");
             });
         });
@@ -459,8 +482,8 @@ describe('unexpected-sinon', function () {
                        "expected stub threw Error()\n" +
                        "\n" +
                        "invocations(\n" +
-                       "  stub() // expected stub() threw Error()\n" +
-                       "         //   expected TypeError() to satisfy Error()\n" +
+                       "  stub() at theFunction (theFileName:xx:yy) // expected stub() at theFunction (theFileName:xx:yy) threw Error()\n" +
+                       "                                            //   expected TypeError() to satisfy Error()\n" +
                        ")");
             });
         });
@@ -492,8 +515,8 @@ describe('unexpected-sinon', function () {
                        "expected spy always threw\n" +
                        "\n" +
                        "invocations(\n" +
-                       "  spy(),\n" +
-                       "  spy() // expected spy() threw\n" +
+                       "  spy() at theFunction (theFileName:xx:yy),\n" +
+                       "  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) threw\n" +
                        ")");
             });
         });
@@ -519,16 +542,16 @@ describe('unexpected-sinon', function () {
                        "expected stub always threw { name: 'Error' }\n" +
                        "\n" +
                        "invocations(\n" +
-                       "  stub(),\n" +
-                       "  stub() // expected stub() threw { name: 'Error' }\n" +
-                       "         //   expected TypeError() to satisfy { name: 'Error' }\n" +
-                       "         //\n" +
-                       "         //   {\n" +
-                       "         //     message: '',\n" +
-                       "         //     name: 'TypeError' // should equal 'Error'\n" +
-                       "         //                       // -TypeError\n" +
-                       "         //                       // +Error\n" +
-                       "         //   }\n" +
+                       "  stub() at theFunction (theFileName:xx:yy),\n" +
+                       "  stub() at theFunction (theFileName:xx:yy) // expected stub() at theFunction (theFileName:xx:yy) threw { name: 'Error' }\n" +
+                       "                                            //   expected TypeError() to satisfy { name: 'Error' }\n" +
+                       "                                            //\n" +
+                       "                                            //   {\n" +
+                       "                                            //     message: '',\n" +
+                       "                                            //     name: 'TypeError' // should equal 'Error'\n" +
+                       "                                            //                       // -TypeError\n" +
+                       "                                            //                       // +Error\n" +
+                       "                                            //   }\n" +
                        ")");
             });
         });
@@ -556,9 +579,9 @@ describe('unexpected-sinon', function () {
                        "expected stub always threw Error()\n" +
                        "\n" +
                        "invocations(\n" +
-                       "  stub(),\n" +
-                       "  stub() // expected stub() threw Error()\n" +
-                       "         //   expected TypeError() to satisfy Error()\n" +
+                       "  stub() at theFunction (theFileName:xx:yy),\n" +
+                       "  stub() at theFunction (theFileName:xx:yy) // expected stub() at theFunction (theFileName:xx:yy) threw Error()\n" +
+                       "                                            //   expected TypeError() to satisfy Error()\n" +
                        ")");
             });
         });

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -345,7 +345,7 @@ describe('unexpected-sinon', function () {
                    "expected spy was never called with 'bar', match(truthy)\n" +
                    "\n" +
                    "invocations(\n" +
-                   "  spy( 'bar', 'true' ) at theFunction (theFileName:xx:yy) // expected spy( 'bar', 'true' ) at theFunction (theFileName:xx:yy) not to satisfy { 0: 'bar', 1: match(truthy) }\n" +
+                   "  spy( 'bar', 'true' ) at theFunction (theFileName:xx:yy) // should not satisfy { 0: 'bar', 1: match(truthy) }\n" +
                    ")");
         });
 
@@ -359,7 +359,7 @@ describe('unexpected-sinon', function () {
                    "\n" +
                    "invocations(\n" +
                    "  spy( 'foo' ) at theFunction (theFileName:xx:yy),\n" +
-                   "  spy( 'bar', {} ) at theFunction (theFileName:xx:yy) // expected spy( 'bar', {} ) at theFunction (theFileName:xx:yy) not to satisfy { 0: 'bar' }\n" +
+                   "  spy( 'bar', {} ) at theFunction (theFileName:xx:yy) // should not satisfy { 0: 'bar' }\n" +
                    ")");
         });
     });

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -262,7 +262,7 @@ describe('unexpected-sinon', function () {
                    "\n" +
                    "invocations(\n" +
                    "  spy() at theFunction (theFileName:xx:yy),\n" +
-                   "  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) was called on { spy: spy }\n" +
+                   "  spy() at theFunction (theFileName:xx:yy) // expected: was called on { spy: spy }\n" +
                    "                                           //   expected spy to be called with { spy: spy } as this but was called with null\n" +
                    ")");
         });
@@ -482,7 +482,7 @@ describe('unexpected-sinon', function () {
                        "expected stub threw Error()\n" +
                        "\n" +
                        "invocations(\n" +
-                       "  stub() at theFunction (theFileName:xx:yy) // expected stub() at theFunction (theFileName:xx:yy) threw Error()\n" +
+                       "  stub() at theFunction (theFileName:xx:yy) // expected: threw Error()\n" +
                        "                                            //   expected TypeError() to satisfy Error()\n" +
                        ")");
             });
@@ -516,7 +516,7 @@ describe('unexpected-sinon', function () {
                        "\n" +
                        "invocations(\n" +
                        "  spy() at theFunction (theFileName:xx:yy),\n" +
-                       "  spy() at theFunction (theFileName:xx:yy) // expected spy() at theFunction (theFileName:xx:yy) threw\n" +
+                       "  spy() at theFunction (theFileName:xx:yy) // expected: threw\n" +
                        ")");
             });
         });
@@ -543,7 +543,7 @@ describe('unexpected-sinon', function () {
                        "\n" +
                        "invocations(\n" +
                        "  stub() at theFunction (theFileName:xx:yy),\n" +
-                       "  stub() at theFunction (theFileName:xx:yy) // expected stub() at theFunction (theFileName:xx:yy) threw { name: 'Error' }\n" +
+                       "  stub() at theFunction (theFileName:xx:yy) // expected: threw { name: 'Error' }\n" +
                        "                                            //   expected TypeError() to satisfy { name: 'Error' }\n" +
                        "                                            //\n" +
                        "                                            //   {\n" +
@@ -580,7 +580,7 @@ describe('unexpected-sinon', function () {
                        "\n" +
                        "invocations(\n" +
                        "  stub() at theFunction (theFileName:xx:yy),\n" +
-                       "  stub() at theFunction (theFileName:xx:yy) // expected stub() at theFunction (theFileName:xx:yy) threw Error()\n" +
+                       "  stub() at theFunction (theFileName:xx:yy) // expected: threw Error()\n" +
                        "                                            //   expected TypeError() to satisfy Error()\n" +
                        ")");
             });


### PR DESCRIPTION
Supported in Sinon 1.16.0+