### PR TITLE
to have calls satisfying: Allow specifying the expected calls with a function

### DIFF
--- a/documentation/assertions/array-like/to-have-calls-satisfying.md
+++ b/documentation/assertions/array-like/to-have-calls-satisfying.md
@@ -73,3 +73,41 @@ expected [ increment, noop ] to have calls satisfying
     //        }
 ]
 ```
+
+You can also specify expected calls as a function that performs them:
+
+```js
+var spy1 = sinon.spy().named('spy1');
+var spy2 = sinon.spy().named('spy2');
+
+spy1(123);
+spy2(456);
+spy1(false);
+spy2(789);
+
+expect([ spy1, spy2 ], 'to have calls satisfying', function () {
+    spy1(123);
+    spy2(456);
+    spy1(expect.it('to be a string'));
+    spy2(789);
+});
+```
+
+```output
+expected [ spy1, spy2 ] to have calls satisfying
+[
+  spy1( 123 )
+  spy2( 456 )
+  spy1( expect.it('to be a string') )
+  spy2( 789 )
+]
+
+[
+  spy1( 123 ) at theFunction (theFileName:xx:yy)
+  spy2( 456 ) at theFunction (theFileName:xx:yy)
+  spy1(
+    false // should be a string
+  ) at theFunction (theFileName:xx:yy)
+  spy2( 789 ) at theFunction (theFileName:xx:yy)
+]
+```

--- a/documentation/assertions/spy/to-have-calls-satisfying.md
+++ b/documentation/assertions/spy/to-have-calls-satisfying.md
@@ -36,3 +36,31 @@ expected increment to have calls satisfying [ { args: [ 42 ] }, { args: [ 20 ] }
   ) at theFunction (theFileName:xx:yy)
 ]
 ```
+
+You can also specify expected calls as a function that performs them:
+
+```js
+var increment = sinon.spy().named('increment');
+increment(1);
+increment(2);
+increment(3);
+
+expect(increment, 'to have calls satisfying', function () {
+    increment(1);
+    increment(expect.it('to be a number'));
+});
+```
+
+```output
+expected increment to have calls satisfying
+[
+  increment( 1 )
+  increment( expect.it('to be a number') )
+]
+
+[
+  increment( 1 ) at theFunction (theFileName:xx:yy)
+  increment( 2 ) at theFunction (theFileName:xx:yy)
+  increment( 3 ) at theFunction (theFileName:xx:yy) // should be removed
+]
+```

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -370,7 +370,57 @@
                 }
             });
 
-            expect.addAssertion('<spy|array> to have calls satisfying <any>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array> to have calls satisfying <function>', function (expect, subject, value) {
+                var spies = subject;
+                if (!Array.isArray(spies)) {
+                    spies = [ spies ];
+                }
+                var originalValues = spies.map(function (spy) {
+                    var originalValue = {};
+                    for (var propertyName in spy) {
+                        if (spy.hasOwnProperty(propertyName) && typeof spy[propertyName] !== 'function') {
+                            if (Array.isArray(spy[propertyName])) {
+                                originalValue[propertyName] = [].concat(spy[propertyName]);
+                            } else {
+                                originalValue[propertyName] = spy[propertyName];
+                            }
+                        }
+                    }
+                    return originalValue;
+                });
+                value();
+                var expectedSpyCalls = [];
+                spies.forEach(function (spy, i) {
+                    var originalValue = originalValues[i];
+                    for (var j = originalValue.args.length ; j < spy.args.length ; j += 1) {
+                        var thisValue = spy.thisValues[j];
+                        var calledWithNew = thisValue instanceof spy;
+                        var expectedSpyCall = {
+                            spy: spy,
+                            args: spy.args[j],
+                            callId: spy.callIds[j],
+                            calledWithNew: calledWithNew
+                        };
+                        if (!calledWithNew) {
+                            expectedSpyCall.thisValue = thisValue;
+                        }
+                        expectedSpyCalls.push(expectedSpyCall);
+                    }
+                    for (var propertyName in originalValue) {
+                        spy[propertyName] = originalValue[propertyName];
+                    }
+                });
+                expectedSpyCalls.sort(function (a, b) {
+                    return a.callId - b.callId;
+                });
+
+                expectedSpyCalls.forEach(function (expectedSpyCall) {
+                    delete expectedSpyCall.callId;
+                });
+                return expect(spies, 'to have calls satisfying', expectedSpyCalls);
+            });
+
+            expect.addAssertion('<spy|array> to have calls satisfying <array|object>', function (expect, subject, value) {
                 var spies = subject;
                 if (!Array.isArray(spies)) {
                     spies = [ spies ];

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -392,35 +392,40 @@
                     return originalValue;
                 });
                 value();
-                var expectedSpyCalls = [];
+                var expectedSpyCallSpecs = [];
                 spies.forEach(function (spy, i) {
                     var originalValue = originalValues[i];
                     for (var j = originalValue.args.length ; j < spy.args.length ; j += 1) {
                         var thisValue = spy.thisValues[j];
                         var calledWithNew = thisValue instanceof spy;
-                        var expectedSpyCall = {
+                        var expectedSpyCallSpec = {
                             spy: spy,
+                            call: spy.getCall(j),
                             args: spy.args[j],
                             callId: spy.callIds[j],
                             calledWithNew: calledWithNew
                         };
-                        if (!calledWithNew) {
-                            expectedSpyCall.thisValue = thisValue;
-                        }
-                        expectedSpyCalls.push(expectedSpyCall);
+                        expectedSpyCallSpec.call.getStackFrames = false;
+                        expectedSpyCallSpecs.push(expectedSpyCallSpec);
                     }
                     for (var propertyName in originalValue) {
                         spy[propertyName] = originalValue[propertyName];
                     }
                 });
-                expectedSpyCalls.sort(function (a, b) {
+                expectedSpyCallSpecs.sort(function (a, b) {
                     return a.callId - b.callId;
                 });
 
-                expectedSpyCalls.forEach(function (expectedSpyCall) {
-                    delete expectedSpyCall.callId;
+                var expectedSpyCalls = [];
+                expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
+                    expectedSpyCalls.push(expectedSpyCallSpec.call);
+                    delete expectedSpyCallSpec.call;
+                    delete expectedSpyCallSpec.callId;
                 });
-                return expect(spies, 'to have calls satisfying', expectedSpyCalls);
+                expect.argsOutput[0] = function (output) {
+                    output.appendInspected(expectedSpyCalls);
+                };
+                return expect(spies, 'to have calls satisfying', expectedSpyCallSpecs);
             });
 
             expect.addAssertion('<spy|array> to have calls satisfying <array|object>', function (expect, subject, value) {

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -142,6 +142,9 @@
                 base: 'array-like',
                 identify: isSpyCall,
                 prefix: function (output, value) {
+                    if (value.thisValue instanceof value.proxy) {
+                        output.jsKeyword('new').sp();
+                    }
                     return output.appendInspected(value.proxy).text('(');
                 },
                 suffix: function (output, value) {

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -165,6 +165,60 @@ describe("documentation tests", function () {
                 "]"
             );
         }
+
+        try {
+            var spy1 = sinon.spy().named('spy1');
+            var spy2 = sinon.spy().named('spy2');
+
+            spy1(123);
+            spy2(456);
+            spy1(false);
+            spy2(789);
+
+            expect([ spy1, spy2 ], 'to have calls satisfying', function () {
+                spy1(123);
+                spy2(456);
+                spy1(expect.it('to be a string'));
+                spy2(789);
+            });
+            expect.fail(function (output) {
+                output.error("expected:").nl();
+                output.code("var spy1 = sinon.spy().named('spy1');").nl();
+                output.code("var spy2 = sinon.spy().named('spy2');").nl();
+                output.code("").nl();
+                output.code("spy1(123);").nl();
+                output.code("spy2(456);").nl();
+                output.code("spy1(false);").nl();
+                output.code("spy2(789);").nl();
+                output.code("").nl();
+                output.code("expect([ spy1, spy2 ], 'to have calls satisfying', function () {").nl();
+                output.code("    spy1(123);").nl();
+                output.code("    spy2(456);").nl();
+                output.code("    spy1(expect.it('to be a string'));").nl();
+                output.code("    spy2(789);").nl();
+                output.code("});").nl();
+                output.error("to throw");
+            });
+        } catch (e) {
+            expect(e, "to have message",
+                "expected [ spy1, spy2 ] to have calls satisfying\n" +
+                "[\n" +
+                "  spy1( 123 )\n" +
+                "  spy2( 456 )\n" +
+                "  spy1( expect.it('to be a string') )\n" +
+                "  spy2( 789 )\n" +
+                "]\n" +
+                "\n" +
+                "[\n" +
+                "  spy1( 123 ) at theFunction (theFileName:xx:yy)\n" +
+                "  spy2( 456 ) at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(\n" +
+                "    false // should be a string\n" +
+                "  ) at theFunction (theFileName:xx:yy)\n" +
+                "  spy2( 789 ) at theFunction (theFileName:xx:yy)\n" +
+                "]"
+            );
+        }
         return expect.promise.all(testPromises);
     });
 
@@ -270,6 +324,45 @@ describe("documentation tests", function () {
                 "    46, // should equal 20\n" +
                 "    'yadda' // should be removed\n" +
                 "  ) at theFunction (theFileName:xx:yy)\n" +
+                "]"
+            );
+        }
+
+        try {
+            var increment = sinon.spy().named('increment');
+            increment(1);
+            increment(2);
+            increment(3);
+
+            expect(increment, 'to have calls satisfying', function () {
+                increment(1);
+                increment(expect.it('to be a number'));
+            });
+            expect.fail(function (output) {
+                output.error("expected:").nl();
+                output.code("var increment = sinon.spy().named('increment');").nl();
+                output.code("increment(1);").nl();
+                output.code("increment(2);").nl();
+                output.code("increment(3);").nl();
+                output.code("").nl();
+                output.code("expect(increment, 'to have calls satisfying', function () {").nl();
+                output.code("    increment(1);").nl();
+                output.code("    increment(expect.it('to be a number'));").nl();
+                output.code("});").nl();
+                output.error("to throw");
+            });
+        } catch (e) {
+            expect(e, "to have message",
+                "expected increment to have calls satisfying\n" +
+                "[\n" +
+                "  increment( 1 )\n" +
+                "  increment( expect.it('to be a number') )\n" +
+                "]\n" +
+                "\n" +
+                "[\n" +
+                "  increment( 1 ) at theFunction (theFileName:xx:yy)\n" +
+                "  increment( 2 ) at theFunction (theFileName:xx:yy)\n" +
+                "  increment( 3 ) at theFunction (theFileName:xx:yy) // should be removed\n" +
                 "]"
             );
         }

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -790,6 +790,68 @@ describe('unexpected-sinon', function () {
             );
         });
 
+        describe('when providing the expected calls as a function', function () {
+            it('should succeed', function () {
+                var spy2 = sinon.spy().named('spy2');
+                spy2(123, 456);
+                /*jshint newcap: false */
+                new spy('abc', false);
+                /*jshint newcap: true */
+                spy(-99, Infinity);
+
+                expect([spy, spy2], 'to have calls satisfying', function () {
+                    spy2(123, 456);
+                    /*jshint newcap: false */
+                    new spy('abc', false);
+                    /*jshint newcap: true */
+                    spy(-99, Infinity);
+                });
+                expect(spy.args, 'to have length', 2);
+                expect(spy.callCount, 'to equal', 2);
+            });
+
+            it('should fail with a diff', function () {
+                var spy2 = sinon.spy().named('spy2');
+                spy2(123, 456, 99);
+                /*jshint newcap: false */
+                spy('abc', true);
+                /*jshint newcap: true */
+                spy(-99, Infinity);
+
+                expect(function () {
+                    expect([spy, spy2], 'to have calls satisfying', function () {
+                        spy2(123, 456);
+                        /*jshint newcap: false */
+                        new spy('abc', false);
+                        /*jshint newcap: true */
+                        spy(-99, Infinity);
+                    });
+                }, 'to throw',
+                    "expected [ spy1, spy2 ] to have calls satisfying\n" +
+                    "function () {\n" +
+                    "  spy2(123, 456);\n" +
+                    "  /*jshint newcap: false */\n" +
+                    "  new spy('abc', false);\n" +
+                    "  /*jshint newcap: true */\n" +
+                    "  spy(-99, Infinity);\n" +
+                    "}\n" +
+                    "\n" +
+                    "[\n" +
+                    "  spy2(\n" +
+                    "    123,\n" +
+                    "    456,\n" +
+                    "    99 // should be removed\n" +
+                    "  ) at theFunction (theFileName:xx:yy)\n" +
+                    "  spy1(\n" +
+                    "    'abc',\n" +
+                    "    true // should equal false\n" +
+                    "  ) at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
+                    "  spy1( -99, Infinity ) at theFunction (theFileName:xx:yy)\n" +
+                    "]"
+                );
+            });
+        });
+
         describe('when asserting whether a call was invoked with the new operator', function () {
             it('should succeed', function () {
                 /*jshint newcap: false */

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -828,13 +828,11 @@ describe('unexpected-sinon', function () {
                     });
                 }, 'to throw',
                     "expected [ spy1, spy2 ] to have calls satisfying\n" +
-                    "function () {\n" +
-                    "  spy2(123, 456);\n" +
-                    "  /*jshint newcap: false */\n" +
-                    "  new spy('abc', false);\n" +
-                    "  /*jshint newcap: true */\n" +
-                    "  spy(-99, Infinity);\n" +
-                    "}\n" +
+                    "[\n" +
+                    "  spy2( 123, 456 )\n" +
+                    "  new spy1( 'abc', false )\n" +
+                    "  spy1( -99, Infinity )\n" +
+                    "]\n" +
                     "\n" +
                     "[\n" +
                     "  spy2(\n" +
@@ -847,8 +845,6 @@ describe('unexpected-sinon', function () {
                     "    true // should equal false\n" +
                     "  ) at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
                     "  new spy1( -99, Infinity ) at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false\n" +
-                    "                                                               //\n" +
-                    "                                                               // this: expected {} to equal undefined\n" +
                     "]"
                 );
             });
@@ -864,10 +860,15 @@ describe('unexpected-sinon', function () {
                     });
                 }, 'to throw',
                     "expected spy1 to have calls satisfying\n" +
-                    "function () {\n" +
-                    "  spy('abc', expect.it('to be true'));\n" +
-                    "  spy('abc', false, expect.it('to be a number').and('to be less than', 100));\n" +
-                    "}\n" +
+                    "[\n" +
+                    "  spy1( 'abc', expect.it('to be true') )\n" +
+                    "  spy1(\n" +
+                    "    'abc',\n" +
+                    "    false,\n" +
+                    "    expect.it('to be a number')\n" +
+                    "            .and('to be less than', 100)\n" +
+                    "  )\n" +
+                    "]\n" +
                     "\n" +
                     "[\n" +
                     "  spy1( 'abc', true ) at theFunction (theFileName:xx:yy)\n" +

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -813,10 +813,10 @@ describe('unexpected-sinon', function () {
             it('should fail with a diff', function () {
                 var spy2 = sinon.spy().named('spy2');
                 spy2(123, 456, 99);
-                /*jshint newcap: false */
                 spy('abc', true);
+                /*jshint newcap: false */
+                new spy(-99, Infinity);
                 /*jshint newcap: true */
-                spy(-99, Infinity);
 
                 expect(function () {
                     expect([spy, spy2], 'to have calls satisfying', function () {
@@ -846,7 +846,9 @@ describe('unexpected-sinon', function () {
                     "    'abc',\n" +
                     "    true // should equal false\n" +
                     "  ) at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
-                    "  spy1( -99, Infinity ) at theFunction (theFileName:xx:yy)\n" +
+                    "  new spy1( -99, Infinity ) at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false\n" +
+                    "                                                               //\n" +
+                    "                                                               // this: expected {} to equal undefined\n" +
                     "]"
                 );
             });
@@ -878,7 +880,7 @@ describe('unexpected-sinon', function () {
                     "expected spy1 to have calls satisfying [ { calledWithNew: false }, { calledWithNew: true } ]\n" +
                     "\n" +
                     "[\n" +
-                    "  spy1() at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false\n" +
+                    "  new spy1() at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false\n" +
                     "  spy1() at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
                     "]"
                 );

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -852,6 +852,34 @@ describe('unexpected-sinon', function () {
                     "]"
                 );
             });
+
+            it('should work with expect.it', function () {
+                spy('abc', true);
+                spy('abc', false, 123);
+
+                expect(function () {
+                    expect(spy, 'to have calls satisfying', function () {
+                        spy('abc', expect.it('to be true'));
+                        spy('abc', false, expect.it('to be a number').and('to be less than', 100));
+                    });
+                }, 'to throw',
+                    "expected spy1 to have calls satisfying\n" +
+                    "function () {\n" +
+                    "  spy('abc', expect.it('to be true'));\n" +
+                    "  spy('abc', false, expect.it('to be a number').and('to be less than', 100));\n" +
+                    "}\n" +
+                    "\n" +
+                    "[\n" +
+                    "  spy1( 'abc', true ) at theFunction (theFileName:xx:yy)\n" +
+                    "  spy1(\n" +
+                    "    'abc',\n" +
+                    "    false,\n" +
+                    "    123 // ✓ should be a number and\n" +
+                    "        // ⨯ should be less than 100\n" +
+                    "  ) at theFunction (theFileName:xx:yy)\n" +
+                    "]"
+                );
+            });
         });
 
         describe('when asserting whether a call was invoked with the new operator', function () {


### PR DESCRIPTION
I mentioned this idea a while ago, and it actually seems to work :)

Showcase: https://github.com/unexpectedjs/array-changes/commit/12eea31590d8575f6e27f83ce72264d7818021ae