### PR TITLE
Add a semicolon to the suffix when inspecting a spy call

### DIFF
--- a/documentation/assertions/array/given-call-order.md
+++ b/documentation/assertions/array/given-call-order.md
@@ -25,9 +25,9 @@ expect([obj.bar, obj.foo, obj.baz], 'given call order');
 expected [ bar, foo, baz ] given call order
 
 [
-  foo() at theFunction (theFileName:xx:yy) // spy: expected foo to be bar
-  bar() at theFunction (theFileName:xx:yy) // spy: expected bar to be foo
-  baz() at theFunction (theFileName:xx:yy)
+  foo(); at theFunction (theFileName:xx:yy) // spy: expected foo to be bar
+  bar(); at theFunction (theFileName:xx:yy) // spy: expected bar to be foo
+  baz(); at theFunction (theFileName:xx:yy)
 ]
 ```
 
@@ -53,8 +53,8 @@ expect([spy1, spy2, spy2], 'given call order');
 expected [ spy1, spy2, spy2 ] given call order
 
 [
-  spy1() at theFunction (theFileName:xx:yy)
-  spy2() at theFunction (theFileName:xx:yy)
-  spy1() at theFunction (theFileName:xx:yy) // spy: expected spy1 to be spy2
+  spy1(); at theFunction (theFileName:xx:yy)
+  spy2(); at theFunction (theFileName:xx:yy)
+  spy1(); at theFunction (theFileName:xx:yy) // spy: expected spy1 to be spy2
 ]
 ```

--- a/documentation/assertions/array/given-call-order.md
+++ b/documentation/assertions/array/given-call-order.md
@@ -24,11 +24,9 @@ expect([obj.bar, obj.foo, obj.baz], 'given call order');
 ```output
 expected [ bar, foo, baz ] given call order
 
-[
-  foo(); at theFunction (theFileName:xx:yy) // spy: expected foo to be bar
-  bar(); at theFunction (theFileName:xx:yy) // spy: expected bar to be foo
-  baz(); at theFunction (theFileName:xx:yy)
-]
+foo(); at theFunction (theFileName:xx:yy) // spy: expected foo to be bar
+bar(); at theFunction (theFileName:xx:yy) // spy: expected bar to be foo
+baz(); at theFunction (theFileName:xx:yy)
 ```
 
 NOTE: This assertion has slightly different semantics from Sinon.js' own
@@ -52,9 +50,7 @@ expect([spy1, spy2, spy2], 'given call order');
 ```output
 expected [ spy1, spy2, spy2 ] given call order
 
-[
-  spy1(); at theFunction (theFileName:xx:yy)
-  spy2(); at theFunction (theFileName:xx:yy)
-  spy1(); at theFunction (theFileName:xx:yy) // spy: expected spy1 to be spy2
-]
+spy1(); at theFunction (theFileName:xx:yy)
+spy2(); at theFunction (theFileName:xx:yy)
+spy1(); at theFunction (theFileName:xx:yy) // spy: expected spy1 to be spy2
 ```

--- a/documentation/assertions/array/to-have-calls-satisfying.md
+++ b/documentation/assertions/array/to-have-calls-satisfying.md
@@ -56,12 +56,12 @@ expected [ increment, noop ] to have calls satisfying
 [
   increment(
     456 // should equal 123
-  ) at theFunction (theFileName:xx:yy)
-  noop( 987 ) at theFunction (theFileName:xx:yy)
-  increment( 123 ) at theFunction (theFileName:xx:yy)
+  ); at theFunction (theFileName:xx:yy)
+  noop( 987 ); at theFunction (theFileName:xx:yy)
+  increment( 123 ); at theFunction (theFileName:xx:yy)
     // returned: expected 124 to equal 557
-  noop( 555 ) at theFunction (theFileName:xx:yy)
-  increment( 666 ) at theFunction (theFileName:xx:yy)
+  noop( 555 ); at theFunction (theFileName:xx:yy)
+  increment( 666 ); at theFunction (theFileName:xx:yy)
     // threw: expected Error('No, I won\'t do that')
     //        to satisfy { message: expect.it('not to match', /^No/) }
     //
@@ -130,18 +130,18 @@ expect([ spy1, spy2 ], 'to have calls satisfying', function () {
 ```output
 expected [ spy1, spy2 ] to have calls satisfying
 [
-  spy1( 123 )
-  spy2( 456 )
-  spy1( expect.it('to be a string') )
-  spy2( 789 )
+  spy1( 123 );
+  spy2( 456 );
+  spy1( expect.it('to be a string') );
+  spy2( 789 );
 ]
 
 [
-  spy1( 123 ) at theFunction (theFileName:xx:yy)
-  spy2( 456 ) at theFunction (theFileName:xx:yy)
+  spy1( 123 ); at theFunction (theFileName:xx:yy)
+  spy2( 456 ); at theFunction (theFileName:xx:yy)
   spy1(
     false // should be a string
-  ) at theFunction (theFileName:xx:yy)
-  spy2( 789 ) at theFunction (theFileName:xx:yy)
+  ); at theFunction (theFileName:xx:yy)
+  spy2( 789 ); at theFunction (theFileName:xx:yy)
 ]
 ```

--- a/documentation/assertions/array/to-have-calls-satisfying.md
+++ b/documentation/assertions/array/to-have-calls-satisfying.md
@@ -53,25 +53,23 @@ expected [ increment, noop ] to have calls satisfying
   }
 ]
 
-[
-  increment(
-    456 // should equal 123
-  ); at theFunction (theFileName:xx:yy)
-  noop( 987 ); at theFunction (theFileName:xx:yy)
-  increment( 123 ); at theFunction (theFileName:xx:yy)
-    // returned: expected 124 to equal 557
-  noop( 555 ); at theFunction (theFileName:xx:yy)
-  increment( 666 ); at theFunction (theFileName:xx:yy)
-    // threw: expected Error('No, I won\'t do that')
-    //        to satisfy { message: expect.it('not to match', /^No/) }
-    //
-    //        {
-    //          message: 'No, I won\'t do that' // should not match /^No/
-    //                                          //
-    //                                          // No, I won't do that
-    //                                          // ^^
-    //        }
-]
+increment(
+  456 // should equal 123
+); at theFunction (theFileName:xx:yy)
+noop( 987 ); at theFunction (theFileName:xx:yy)
+increment( 123 ); at theFunction (theFileName:xx:yy)
+  // returned: expected 124 to equal 557
+noop( 555 ); at theFunction (theFileName:xx:yy)
+increment( 666 ); at theFunction (theFileName:xx:yy)
+  // threw: expected Error('No, I won\'t do that')
+  //        to satisfy { message: expect.it('not to match', /^No/) }
+  //
+  //        {
+  //          message: 'No, I won\'t do that' // should not match /^No/
+  //                                          //
+  //                                          // No, I won't do that
+  //                                          // ^^
+  //        }
 ```
 
 Note that the individual arguments are matched with
@@ -98,14 +96,12 @@ expect([ mySpy ], 'to have calls exhaustively satisfying', [
 ```output
 expected [ mySpy ] to have calls exhaustively satisfying [ { args: [ ... ] } ]
 
-[
-  mySpy(
-    {
-      foo: 123,
-      bar: 456 // should be removed
-    }
-  ) at theFunction (theFileName:xx:yy)
-]
+mySpy(
+  {
+    foo: 123,
+    bar: 456 // should be removed
+  }
+); at theFunction (theFileName:xx:yy)
 ```
 
 You can also specify expected calls as a function that performs them:
@@ -129,19 +125,15 @@ expect([ spy1, spy2 ], 'to have calls satisfying', function () {
 
 ```output
 expected [ spy1, spy2 ] to have calls satisfying
-[
-  spy1( 123 );
-  spy2( 456 );
-  spy1( expect.it('to be a string') );
-  spy2( 789 );
-]
+spy1( 123 );
+spy2( 456 );
+spy1( expect.it('to be a string') );
+spy2( 789 );
 
-[
-  spy1( 123 ); at theFunction (theFileName:xx:yy)
-  spy2( 456 ); at theFunction (theFileName:xx:yy)
-  spy1(
-    false // should be a string
-  ); at theFunction (theFileName:xx:yy)
-  spy2( 789 ); at theFunction (theFileName:xx:yy)
-]
+spy1( 123 ); at theFunction (theFileName:xx:yy)
+spy2( 456 ); at theFunction (theFileName:xx:yy)
+spy1(
+  false // should be a string
+); at theFunction (theFileName:xx:yy)
+spy2( 789 ); at theFunction (theFileName:xx:yy)
 ```

--- a/documentation/assertions/spy/threw.md
+++ b/documentation/assertions/spy/threw.md
@@ -50,9 +50,9 @@ expect(stub, 'always threw', /waat/);
 expected myStub always threw /waat/
 
 [
-  myStub() at theFunction (theFileName:xx:yy)
+  myStub(); at theFunction (theFileName:xx:yy)
   // expected: threw /waat/
   //   expected TypeError('wat') to satisfy /waat/
-  myStub() at theFunction (theFileName:xx:yy)
+  myStub(); at theFunction (theFileName:xx:yy)
 ]
 ```

--- a/documentation/assertions/spy/threw.md
+++ b/documentation/assertions/spy/threw.md
@@ -49,10 +49,8 @@ expect(stub, 'always threw', /waat/);
 ```output
 expected myStub always threw /waat/
 
-[
-  myStub(); at theFunction (theFileName:xx:yy)
-  // expected: threw /waat/
-  //   expected TypeError('wat') to satisfy /waat/
-  myStub(); at theFunction (theFileName:xx:yy)
-]
+myStub(); at theFunction (theFileName:xx:yy)
+// expected: threw /waat/
+//   expected TypeError('wat') to satisfy /waat/
+myStub(); at theFunction (theFileName:xx:yy)
 ```

--- a/documentation/assertions/spy/to-have-calls-satisfying.md
+++ b/documentation/assertions/spy/to-have-calls-satisfying.md
@@ -29,11 +29,11 @@ expect(increment, 'to have calls satisfying', [
 expected increment to have calls satisfying [ { args: [ 42 ] }, { args: [ 20 ] } ]
 
 [
-  increment( 42 ) at theFunction (theFileName:xx:yy)
+  increment( 42 ); at theFunction (theFileName:xx:yy)
   increment(
     46, // should equal 20
     'yadda' // should be removed
-  ) at theFunction (theFileName:xx:yy)
+  ); at theFunction (theFileName:xx:yy)
 ]
 ```
 
@@ -88,13 +88,13 @@ expect(increment, 'to have calls satisfying', function () {
 ```output
 expected increment to have calls satisfying
 [
-  increment( 1 )
-  increment( expect.it('to be a number') )
+  increment( 1 );
+  increment( expect.it('to be a number') );
 ]
 
 [
-  increment( 1 ) at theFunction (theFileName:xx:yy)
-  increment( 2 ) at theFunction (theFileName:xx:yy)
-  increment( 3 ) at theFunction (theFileName:xx:yy) // should be removed
+  increment( 1 ); at theFunction (theFileName:xx:yy)
+  increment( 2 ); at theFunction (theFileName:xx:yy)
+  increment( 3 ); at theFunction (theFileName:xx:yy) // should be removed
 ]
 ```

--- a/documentation/assertions/spy/to-have-calls-satisfying.md
+++ b/documentation/assertions/spy/to-have-calls-satisfying.md
@@ -28,13 +28,11 @@ expect(increment, 'to have calls satisfying', [
 ```output
 expected increment to have calls satisfying [ { args: [ 42 ] }, { args: [ 20 ] } ]
 
-[
-  increment( 42 ); at theFunction (theFileName:xx:yy)
-  increment(
-    46, // should equal 20
-    'yadda' // should be removed
-  ); at theFunction (theFileName:xx:yy)
-]
+increment( 42 ); at theFunction (theFileName:xx:yy)
+increment(
+  46, // should equal 20
+  'yadda' // should be removed
+); at theFunction (theFileName:xx:yy)
 ```
 
 Note that the individual arguments are matched with
@@ -61,14 +59,12 @@ expect(mySpy, 'to have calls exhaustively satisfying', [
 ```output
 expected mySpy to have calls exhaustively satisfying [ { args: [ ... ] } ]
 
-[
-  mySpy(
-    {
-      foo: 123,
-      bar: 456 // should be removed
-    }
-  ) at theFunction (theFileName:xx:yy)
-]
+mySpy(
+  {
+    foo: 123,
+    bar: 456 // should be removed
+  }
+); at theFunction (theFileName:xx:yy)
 ```
 
 You can also specify expected calls as a function that performs them:
@@ -87,14 +83,10 @@ expect(increment, 'to have calls satisfying', function () {
 
 ```output
 expected increment to have calls satisfying
-[
-  increment( 1 );
-  increment( expect.it('to be a number') );
-]
+increment( 1 );
+increment( expect.it('to be a number') );
 
-[
-  increment( 1 ); at theFunction (theFileName:xx:yy)
-  increment( 2 ); at theFunction (theFileName:xx:yy)
-  increment( 3 ); at theFunction (theFileName:xx:yy) // should be removed
-]
+increment( 1 ); at theFunction (theFileName:xx:yy)
+increment( 2 ); at theFunction (theFileName:xx:yy)
+increment( 3 ); at theFunction (theFileName:xx:yy) // should be removed
 ```

--- a/documentation/assertions/spy/was-called-on.md
+++ b/documentation/assertions/spy/was-called-on.md
@@ -16,11 +16,9 @@ expect(obj.spy, 'was called on', another);
 ```output
 expected mySpy was called on {}
 
-[
-  mySpy(); at theFunction (theFileName:xx:yy)
-  // expected: was called on {}
-  //   expected mySpy to be called with {} as this but was called with { spy: mySpy }
-]
+mySpy(); at theFunction (theFileName:xx:yy)
+// expected: was called on {}
+//   expected mySpy to be called with {} as this but was called with { spy: mySpy }
 ```
 
 You can make this assertion more strict by using the `always`
@@ -41,10 +39,8 @@ expect(obj.spy, 'was always called on', obj);
 ```output
 expected mySpy was always called on { spy: mySpy }
 
-[
-  mySpy(); at theFunction (theFileName:xx:yy)
-  mySpy(); at theFunction (theFileName:xx:yy)
-  // expected: was called on { spy: mySpy }
-  //   expected mySpy to be called with { spy: mySpy } as this but was called with {}
-]
+mySpy(); at theFunction (theFileName:xx:yy)
+mySpy(); at theFunction (theFileName:xx:yy)
+// expected: was called on { spy: mySpy }
+//   expected mySpy to be called with { spy: mySpy } as this but was called with {}
 ```

--- a/documentation/assertions/spy/was-called-on.md
+++ b/documentation/assertions/spy/was-called-on.md
@@ -17,7 +17,7 @@ expect(obj.spy, 'was called on', another);
 expected mySpy was called on {}
 
 [
-  mySpy() at theFunction (theFileName:xx:yy)
+  mySpy(); at theFunction (theFileName:xx:yy)
   // expected: was called on {}
   //   expected mySpy to be called with {} as this but was called with { spy: mySpy }
 ]
@@ -42,8 +42,8 @@ expect(obj.spy, 'was always called on', obj);
 expected mySpy was always called on { spy: mySpy }
 
 [
-  mySpy() at theFunction (theFileName:xx:yy)
-  mySpy() at theFunction (theFileName:xx:yy)
+  mySpy(); at theFunction (theFileName:xx:yy)
+  mySpy(); at theFunction (theFileName:xx:yy)
   // expected: was called on { spy: mySpy }
   //   expected mySpy to be called with { spy: mySpy } as this but was called with {}
 ]

--- a/documentation/assertions/spy/was-called-times.md
+++ b/documentation/assertions/spy/was-called-times.md
@@ -22,12 +22,10 @@ expect(add, 'was called times', 2);
 ```output
 expected add was called times 2
   expected
-  [
-    add( 41, 42 ); at theFunction (theFileName:xx:yy)
-    add( 41, 43 ); at theFunction (theFileName:xx:yy)
-    add( 41, 44 ); at theFunction (theFileName:xx:yy)
-    add( 41, 45 ); at theFunction (theFileName:xx:yy)
-  ]
+  add( 41, 42 ); at theFunction (theFileName:xx:yy)
+  add( 41, 43 ); at theFunction (theFileName:xx:yy)
+  add( 41, 44 ); at theFunction (theFileName:xx:yy)
+  add( 41, 45 ); at theFunction (theFileName:xx:yy)
   to have length 2
     expected 4 to be 2
 ```

--- a/documentation/assertions/spy/was-called-times.md
+++ b/documentation/assertions/spy/was-called-times.md
@@ -23,10 +23,10 @@ expect(add, 'was called times', 2);
 expected add was called times 2
   expected
   [
-    add( 41, 42 ) at theFunction (theFileName:xx:yy)
-    add( 41, 43 ) at theFunction (theFileName:xx:yy)
-    add( 41, 44 ) at theFunction (theFileName:xx:yy)
-    add( 41, 45 ) at theFunction (theFileName:xx:yy)
+    add( 41, 42 ); at theFunction (theFileName:xx:yy)
+    add( 41, 43 ); at theFunction (theFileName:xx:yy)
+    add( 41, 44 ); at theFunction (theFileName:xx:yy)
+    add( 41, 45 ); at theFunction (theFileName:xx:yy)
   ]
   to have length 2
     expected 4 to be 2

--- a/documentation/assertions/spy/was-called-with.md
+++ b/documentation/assertions/spy/was-called-with.md
@@ -15,14 +15,12 @@ expect(mySpy, 'was called with', 'baz', { foo: 'bar' });
 ```output
 expected mySpy was called with 'baz', { foo: 'bar' }
 
-[
-  mySpy(
-    { foo: 'bar' }, // should equal 'baz'
-    'baz', // should equal { foo: 'bar' }
-    'qux',
-    'quux'
-  ); at theFunction (theFileName:xx:yy)
-]
+mySpy(
+  { foo: 'bar' }, // should equal 'baz'
+  'baz', // should equal { foo: 'bar' }
+  'qux',
+  'quux'
+); at theFunction (theFileName:xx:yy)
 ```
 
 You can make this assertion more strict using the `always` flag. Then
@@ -46,15 +44,13 @@ expect(mySpy, 'was always called with', { foo: 'bar' }, 'baz', expect.it('to be 
 expected mySpy
 was always called with { foo: 'bar' }, 'baz', expect.it('to be truthy')
 
-[
-  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)
-  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)
-  mySpy(
-    { foo: 'bar' },
-    'baz'
-    // missing: should be truthy
-  ); at theFunction (theFileName:xx:yy)
-]
+mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)
+mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)
+mySpy(
+  { foo: 'bar' },
+  'baz'
+  // missing: should be truthy
+); at theFunction (theFileName:xx:yy)
 ```
 
 I case you want to ensure that the spy was called with the provided
@@ -76,14 +72,12 @@ expect(mySpy, 'was called with exactly', { foo: 'bar' }, 'baz', expect.it('to be
 expected mySpy
 was called with exactly { foo: 'bar' }, 'baz', expect.it('to be truthy')
 
-[
-  mySpy(
-    { foo: 'bar' },
-    'baz',
-    'qux',
-    'quux' // should be removed
-  ); at theFunction (theFileName:xx:yy)
-]
+mySpy(
+  { foo: 'bar' },
+  'baz',
+  'qux',
+  'quux' // should be removed
+); at theFunction (theFileName:xx:yy)
 ```
 
 It is of course also possible to combine the two flags, that will then
@@ -108,13 +102,11 @@ expect(mySpy, 'was always called with exactly', { foo: 'bar' }, 'baz', expect.it
 expected mySpy
 was always called with exactly { foo: 'bar' }, 'baz', expect.it('to be truthy')
 
-[
-  mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)
-  mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)
-  mySpy(
-    { foo: 'bar' },
-    'baz'
-    // missing: should be truthy
-  ); at theFunction (theFileName:xx:yy)
-]
+mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)
+mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)
+mySpy(
+  { foo: 'bar' },
+  'baz'
+  // missing: should be truthy
+); at theFunction (theFileName:xx:yy)
 ```

--- a/documentation/assertions/spy/was-called-with.md
+++ b/documentation/assertions/spy/was-called-with.md
@@ -21,7 +21,7 @@ expected mySpy was called with 'baz', { foo: 'bar' }
     'baz', // should equal { foo: 'bar' }
     'qux',
     'quux'
-  ) at theFunction (theFileName:xx:yy)
+  ); at theFunction (theFileName:xx:yy)
 ]
 ```
 
@@ -47,13 +47,13 @@ expected mySpy
 was always called with { foo: 'bar' }, 'baz', expect.it('to be truthy')
 
 [
-  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ) at theFunction (theFileName:xx:yy)
-  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ) at theFunction (theFileName:xx:yy)
+  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)
+  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)
   mySpy(
     { foo: 'bar' },
     'baz'
     // missing: should be truthy
-  ) at theFunction (theFileName:xx:yy)
+  ); at theFunction (theFileName:xx:yy)
 ]
 ```
 
@@ -82,7 +82,7 @@ was called with exactly { foo: 'bar' }, 'baz', expect.it('to be truthy')
     'baz',
     'qux',
     'quux' // should be removed
-  ) at theFunction (theFileName:xx:yy)
+  ); at theFunction (theFileName:xx:yy)
 ]
 ```
 
@@ -109,12 +109,12 @@ expected mySpy
 was always called with exactly { foo: 'bar' }, 'baz', expect.it('to be truthy')
 
 [
-  mySpy( { foo: 'bar' }, 'baz', 'qux' ) at theFunction (theFileName:xx:yy)
-  mySpy( { foo: 'bar' }, 'baz', 'qux' ) at theFunction (theFileName:xx:yy)
+  mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)
+  mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)
   mySpy(
     { foo: 'bar' },
     'baz'
     // missing: should be truthy
-  ) at theFunction (theFileName:xx:yy)
+  ); at theFunction (theFileName:xx:yy)
 ]
 ```

--- a/documentation/assertions/spy/was-called.md
+++ b/documentation/assertions/spy/was-called.md
@@ -33,7 +33,5 @@ expect(add, 'was not called');
 ```output
 expected add was not called
 
-[
-  add( 42, 42 ); at theFunction (theFileName:xx:yy) // should be removed
-]
+add( 42, 42 ); at theFunction (theFileName:xx:yy) // should be removed
 ```

--- a/documentation/assertions/spy/was-called.md
+++ b/documentation/assertions/spy/was-called.md
@@ -34,6 +34,6 @@ expect(add, 'was not called');
 expected add was not called
 
 [
-  add( 42, 42 ) at theFunction (theFileName:xx:yy) // should be removed
+  add( 42, 42 ); at theFunction (theFileName:xx:yy) // should be removed
 ]
 ```

--- a/documentation/assertions/spyCall/to-satisfy.md
+++ b/documentation/assertions/spyCall/to-satisfy.md
@@ -26,12 +26,12 @@ expect(decrement.secondCall, 'to satisfy', { args: [ 20 ] });
 ```
 
 ```output
-expected decrement( 200 ) at theFunction (theFileName:xx:yy)
+expected decrement( 200 ); at theFunction (theFileName:xx:yy)
 to satisfy { args: [ 20 ] }
 
 decrement(
   200 // should equal 20
-) at theFunction (theFileName:xx:yy)
+); at theFunction (theFileName:xx:yy)
 ```
 
 All the semantics of [to satisfy](http://unexpected.js.org/assertions/any/to-satisfy/)

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -106,7 +106,7 @@
                     return output.appendInspected(value.proxy).text('(');
                 },
                 suffix: function (output, value) {
-                    output.text(')');
+                    output.text(');');
                     var stackFrames = value.getStackFrames && value.getStackFrames();
                     if (Array.isArray(stackFrames) && stackFrames.length > 0) {
                         output.sp().jsComment('at ' + makePathsRelativeToCwdOrLocation(stackFrames[0].replace(/^\s*(?:at\s+|@)?/, '')));

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -150,16 +150,15 @@
                         return baseType.similar(aItem, b.args[index]);
                     });
                 },
+                indent: false,
+                multipleLine: false,
+                leadingNewline: false,
+                trailingNewline: false,
                 inspect: function (spyCalls, depth, output, inspect) {
-                    this.prefix(output);
-                    output.nl()
-                        .indentLines()
-                        .i().block(function (output) {
+                    output
+                        .block(function (output) {
                             output.appendItems(spyCalls, '\n');
-                        })
-                        .nl()
-                        .outdentLines();
-                    this.suffix(output);
+                        });
                 }
             });
 

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -134,6 +134,12 @@
             expect.addType({
                 name: 'spyCalls',
                 base: 'array-like',
+                prefix: function (output) {
+                    return output;
+                },
+                suffix: function (output) {
+                    return output;
+                },
                 delimiter: function (output) {
                     return output;
                 },

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -151,7 +151,7 @@
                     });
                 },
                 indent: false,
-                multipleLine: false,
+                forceMultipleLines: true,
                 leadingNewline: false,
                 trailingNewline: false,
                 inspect: function (spyCalls, depth, output, inspect) {

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -88,10 +88,10 @@
                     return value && value._isSpyArguments;
                 },
                 prefix: function (output, value) {
-                    return output;
+                    return output.text('(');
                 },
                 suffix: function (output) {
-                    return output;
+                    return output.text(');');
                 }
             });
 
@@ -103,10 +103,9 @@
                     if (value.thisValue instanceof value.proxy) {
                         output.jsKeyword('new').sp();
                     }
-                    return output.appendInspected(value.proxy).text('(');
+                    return output.appendInspected(value.proxy);
                 },
                 suffix: function (output, value) {
-                    output.text(');');
                     var stackFrames = value.getStackFrames && value.getStackFrames();
                     if (Array.isArray(stackFrames) && stackFrames.length > 0) {
                         output.sp().jsComment('at ' + makePathsRelativeToCwdOrLocation(stackFrames[0].replace(/^\s*(?:at\s+|@)?/, '')));
@@ -152,8 +151,6 @@
                 },
                 indent: false,
                 forceMultipleLines: true,
-                leadingNewline: false,
-                trailingNewline: false,
                 inspect: function (spyCalls, depth, output, inspect) {
                     output
                         .block(function (output) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mocha": "2.2.5",
     "serve": "*",
     "sinon": "1.16.1",
-    "unexpected": "10.5.1",
+    "unexpected": "unexpectedjs/unexpected#feature/customizeIndentAndNewlines",
     "unexpected-documentation-site-generator": "^3.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mocha": "2.2.5",
     "serve": "*",
     "sinon": "1.16.1",
-    "unexpected": "unexpectedjs/unexpected#feature/customizeIndentAndNewlines",
+    "unexpected": "10.6.0",
     "unexpected-documentation-site-generator": "^3.3.1"
   }
 }

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -43,9 +43,9 @@ describe("documentation tests", function () {
                 "expected [ bar, foo, baz ] given call order\n" +
                 "\n" +
                 "[\n" +
-                "  foo() at theFunction (theFileName:xx:yy) // spy: expected foo to be bar\n" +
-                "  bar() at theFunction (theFileName:xx:yy) // spy: expected bar to be foo\n" +
-                "  baz() at theFunction (theFileName:xx:yy)\n" +
+                "  foo(); at theFunction (theFileName:xx:yy) // spy: expected foo to be bar\n" +
+                "  bar(); at theFunction (theFileName:xx:yy) // spy: expected bar to be foo\n" +
+                "  baz(); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         }
@@ -74,9 +74,9 @@ describe("documentation tests", function () {
                 "expected [ spy1, spy2, spy2 ] given call order\n" +
                 "\n" +
                 "[\n" +
-                "  spy1() at theFunction (theFileName:xx:yy)\n" +
-                "  spy2() at theFunction (theFileName:xx:yy)\n" +
-                "  spy1() at theFunction (theFileName:xx:yy) // spy: expected spy1 to be spy2\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy2(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy) // spy: expected spy1 to be spy2\n" +
                 "]"
             );
         }
@@ -147,12 +147,12 @@ describe("documentation tests", function () {
                 "[\n" +
                 "  increment(\n" +
                 "    456 // should equal 123\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
-                "  noop( 987 ) at theFunction (theFileName:xx:yy)\n" +
-                "  increment( 123 ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
+                "  noop( 987 ); at theFunction (theFileName:xx:yy)\n" +
+                "  increment( 123 ); at theFunction (theFileName:xx:yy)\n" +
                 "    // returned: expected 124 to equal 557\n" +
-                "  noop( 555 ) at theFunction (theFileName:xx:yy)\n" +
-                "  increment( 666 ) at theFunction (theFileName:xx:yy)\n" +
+                "  noop( 555 ); at theFunction (theFileName:xx:yy)\n" +
+                "  increment( 666 ); at theFunction (theFileName:xx:yy)\n" +
                 "    // threw: expected Error('No, I won\\'t do that')\n" +
                 "    //        to satisfy { message: expect.it('not to match', /^No/) }\n" +
                 "    //\n" +
@@ -235,19 +235,19 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected [ spy1, spy2 ] to have calls satisfying\n" +
                 "[\n" +
-                "  spy1( 123 )\n" +
-                "  spy2( 456 )\n" +
-                "  spy1( expect.it('to be a string') )\n" +
-                "  spy2( 789 )\n" +
+                "  spy1( 123 );\n" +
+                "  spy2( 456 );\n" +
+                "  spy1( expect.it('to be a string') );\n" +
+                "  spy2( 789 );\n" +
                 "]\n" +
                 "\n" +
                 "[\n" +
-                "  spy1( 123 ) at theFunction (theFileName:xx:yy)\n" +
-                "  spy2( 456 ) at theFunction (theFileName:xx:yy)\n" +
+                "  spy1( 123 ); at theFunction (theFileName:xx:yy)\n" +
+                "  spy2( 456 ); at theFunction (theFileName:xx:yy)\n" +
                 "  spy1(\n" +
                 "    false // should be a string\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
-                "  spy2( 789 ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
+                "  spy2( 789 ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         }
@@ -303,10 +303,10 @@ describe("documentation tests", function () {
                 "expected myStub always threw /waat/\n" +
                 "\n" +
                 "[\n" +
-                "  myStub() at theFunction (theFileName:xx:yy)\n" +
+                "  myStub(); at theFunction (theFileName:xx:yy)\n" +
                 "  // expected: threw /waat/\n" +
                 "  //   expected TypeError('wat') to satisfy /waat/\n" +
-                "  myStub() at theFunction (theFileName:xx:yy)\n" +
+                "  myStub(); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         }
@@ -351,11 +351,11 @@ describe("documentation tests", function () {
                 "expected increment to have calls satisfying [ { args: [ 42 ] }, { args: [ 20 ] } ]\n" +
                 "\n" +
                 "[\n" +
-                "  increment( 42 ) at theFunction (theFileName:xx:yy)\n" +
+                "  increment( 42 ); at theFunction (theFileName:xx:yy)\n" +
                 "  increment(\n" +
                 "    46, // should equal 20\n" +
                 "    'yadda' // should be removed\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         }
@@ -419,14 +419,14 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected increment to have calls satisfying\n" +
                 "[\n" +
-                "  increment( 1 )\n" +
-                "  increment( expect.it('to be a number') )\n" +
+                "  increment( 1 );\n" +
+                "  increment( expect.it('to be a number') );\n" +
                 "]\n" +
                 "\n" +
                 "[\n" +
-                "  increment( 1 ) at theFunction (theFileName:xx:yy)\n" +
-                "  increment( 2 ) at theFunction (theFileName:xx:yy)\n" +
-                "  increment( 3 ) at theFunction (theFileName:xx:yy) // should be removed\n" +
+                "  increment( 1 ); at theFunction (theFileName:xx:yy)\n" +
+                "  increment( 2 ); at theFunction (theFileName:xx:yy)\n" +
+                "  increment( 3 ); at theFunction (theFileName:xx:yy) // should be removed\n" +
                 "]"
             );
         }
@@ -453,7 +453,7 @@ describe("documentation tests", function () {
                 "expected mySpy was called on {}\n" +
                 "\n" +
                 "[\n" +
-                "  mySpy() at theFunction (theFileName:xx:yy)\n" +
+                "  mySpy(); at theFunction (theFileName:xx:yy)\n" +
                 "  // expected: was called on {}\n" +
                 "  //   expected mySpy to be called with {} as this but was called with { spy: mySpy }\n" +
                 "]"
@@ -476,8 +476,8 @@ describe("documentation tests", function () {
                 "expected mySpy was always called on { spy: mySpy }\n" +
                 "\n" +
                 "[\n" +
-                "  mySpy() at theFunction (theFileName:xx:yy)\n" +
-                "  mySpy() at theFunction (theFileName:xx:yy)\n" +
+                "  mySpy(); at theFunction (theFileName:xx:yy)\n" +
+                "  mySpy(); at theFunction (theFileName:xx:yy)\n" +
                 "  // expected: was called on { spy: mySpy }\n" +
                 "  //   expected mySpy to be called with { spy: mySpy } as this but was called with {}\n" +
                 "]"
@@ -516,10 +516,10 @@ describe("documentation tests", function () {
                 "expected add was called times 2\n" +
                 "  expected\n" +
                 "  [\n" +
-                "    add( 41, 42 ) at theFunction (theFileName:xx:yy)\n" +
-                "    add( 41, 43 ) at theFunction (theFileName:xx:yy)\n" +
-                "    add( 41, 44 ) at theFunction (theFileName:xx:yy)\n" +
-                "    add( 41, 45 ) at theFunction (theFileName:xx:yy)\n" +
+                "    add( 41, 42 ); at theFunction (theFileName:xx:yy)\n" +
+                "    add( 41, 43 ); at theFunction (theFileName:xx:yy)\n" +
+                "    add( 41, 44 ); at theFunction (theFileName:xx:yy)\n" +
+                "    add( 41, 45 ); at theFunction (theFileName:xx:yy)\n" +
                 "  ]\n" +
                 "  to have length 2\n" +
                 "    expected 4 to be 2"
@@ -559,7 +559,7 @@ describe("documentation tests", function () {
                 "    'baz', // should equal { foo: 'bar' }\n" +
                 "    'qux',\n" +
                 "    'quux'\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         }
@@ -584,13 +584,13 @@ describe("documentation tests", function () {
                 "was always called with { foo: 'bar' }, 'baz', expect.it('to be truthy')\n" +
                 "\n" +
                 "[\n" +
-                "  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ) at theFunction (theFileName:xx:yy)\n" +
-                "  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ) at theFunction (theFileName:xx:yy)\n" +
+                "  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)\n" +
+                "  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)\n" +
                 "  mySpy(\n" +
                 "    { foo: 'bar' },\n" +
                 "    'baz'\n" +
                 "    // missing: should be truthy\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         }
@@ -617,7 +617,7 @@ describe("documentation tests", function () {
                 "    'baz',\n" +
                 "    'qux',\n" +
                 "    'quux' // should be removed\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         }
@@ -642,13 +642,13 @@ describe("documentation tests", function () {
                 "was always called with exactly { foo: 'bar' }, 'baz', expect.it('to be truthy')\n" +
                 "\n" +
                 "[\n" +
-                "  mySpy( { foo: 'bar' }, 'baz', 'qux' ) at theFunction (theFileName:xx:yy)\n" +
-                "  mySpy( { foo: 'bar' }, 'baz', 'qux' ) at theFunction (theFileName:xx:yy)\n" +
+                "  mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)\n" +
+                "  mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)\n" +
                 "  mySpy(\n" +
                 "    { foo: 'bar' },\n" +
                 "    'baz'\n" +
                 "    // missing: should be truthy\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         }
@@ -692,7 +692,7 @@ describe("documentation tests", function () {
                 "expected add was not called\n" +
                 "\n" +
                 "[\n" +
-                "  add( 42, 42 ) at theFunction (theFileName:xx:yy) // should be removed\n" +
+                "  add( 42, 42 ); at theFunction (theFileName:xx:yy) // should be removed\n" +
                 "]"
             );
         }

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -42,11 +42,9 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected [ bar, foo, baz ] given call order\n" +
                 "\n" +
-                "[\n" +
-                "  foo(); at theFunction (theFileName:xx:yy) // spy: expected foo to be bar\n" +
-                "  bar(); at theFunction (theFileName:xx:yy) // spy: expected bar to be foo\n" +
-                "  baz(); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "foo(); at theFunction (theFileName:xx:yy) // spy: expected foo to be bar\n" +
+                "bar(); at theFunction (theFileName:xx:yy) // spy: expected bar to be foo\n" +
+                "baz(); at theFunction (theFileName:xx:yy)"
             );
         }
 
@@ -73,11 +71,9 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected [ spy1, spy2, spy2 ] given call order\n" +
                 "\n" +
-                "[\n" +
-                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "  spy2(); at theFunction (theFileName:xx:yy)\n" +
-                "  spy1(); at theFunction (theFileName:xx:yy) // spy: expected spy1 to be spy2\n" +
-                "]"
+                "spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "spy2(); at theFunction (theFileName:xx:yy)\n" +
+                "spy1(); at theFunction (theFileName:xx:yy) // spy: expected spy1 to be spy2"
             );
         }
         return expect.promise.all(testPromises);
@@ -144,25 +140,23 @@ describe("documentation tests", function () {
                 "  }\n" +
                 "]\n" +
                 "\n" +
-                "[\n" +
-                "  increment(\n" +
-                "    456 // should equal 123\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "  noop( 987 ); at theFunction (theFileName:xx:yy)\n" +
-                "  increment( 123 ); at theFunction (theFileName:xx:yy)\n" +
-                "    // returned: expected 124 to equal 557\n" +
-                "  noop( 555 ); at theFunction (theFileName:xx:yy)\n" +
-                "  increment( 666 ); at theFunction (theFileName:xx:yy)\n" +
-                "    // threw: expected Error('No, I won\\'t do that')\n" +
-                "    //        to satisfy { message: expect.it('not to match', /^No/) }\n" +
-                "    //\n" +
-                "    //        {\n" +
-                "    //          message: 'No, I won\\'t do that' // should not match /^No/\n" +
-                "    //                                          //\n" +
-                "    //                                          // No, I won't do that\n" +
-                "    //                                          // ^^\n" +
-                "    //        }\n" +
-                "]"
+                "increment(\n" +
+                "  456 // should equal 123\n" +
+                "); at theFunction (theFileName:xx:yy)\n" +
+                "noop( 987 ); at theFunction (theFileName:xx:yy)\n" +
+                "increment( 123 ); at theFunction (theFileName:xx:yy)\n" +
+                "  // returned: expected 124 to equal 557\n" +
+                "noop( 555 ); at theFunction (theFileName:xx:yy)\n" +
+                "increment( 666 ); at theFunction (theFileName:xx:yy)\n" +
+                "  // threw: expected Error('No, I won\\'t do that')\n" +
+                "  //        to satisfy { message: expect.it('not to match', /^No/) }\n" +
+                "  //\n" +
+                "  //        {\n" +
+                "  //          message: 'No, I won\\'t do that' // should not match /^No/\n" +
+                "  //                                          //\n" +
+                "  //                                          // No, I won't do that\n" +
+                "  //                                          // ^^\n" +
+                "  //        }"
             );
         }
 
@@ -187,14 +181,12 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected [ mySpy ] to have calls exhaustively satisfying [ { args: [ ... ] } ]\n" +
                 "\n" +
-                "[\n" +
-                "  mySpy(\n" +
-                "    {\n" +
-                "      foo: 123,\n" +
-                "      bar: 456 // should be removed\n" +
-                "    }\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "mySpy(\n" +
+                "  {\n" +
+                "    foo: 123,\n" +
+                "    bar: 456 // should be removed\n" +
+                "  }\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         }
 
@@ -234,21 +226,17 @@ describe("documentation tests", function () {
         } catch (e) {
             expect(e, "to have message",
                 "expected [ spy1, spy2 ] to have calls satisfying\n" +
-                "[\n" +
-                "  spy1( 123 );\n" +
-                "  spy2( 456 );\n" +
-                "  spy1( expect.it('to be a string') );\n" +
-                "  spy2( 789 );\n" +
-                "]\n" +
+                "spy1( 123 );\n" +
+                "spy2( 456 );\n" +
+                "spy1( expect.it('to be a string') );\n" +
+                "spy2( 789 );\n" +
                 "\n" +
-                "[\n" +
-                "  spy1( 123 ); at theFunction (theFileName:xx:yy)\n" +
-                "  spy2( 456 ); at theFunction (theFileName:xx:yy)\n" +
-                "  spy1(\n" +
-                "    false // should be a string\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "  spy2( 789 ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "spy1( 123 ); at theFunction (theFileName:xx:yy)\n" +
+                "spy2( 456 ); at theFunction (theFileName:xx:yy)\n" +
+                "spy1(\n" +
+                "  false // should be a string\n" +
+                "); at theFunction (theFileName:xx:yy)\n" +
+                "spy2( 789 ); at theFunction (theFileName:xx:yy)"
             );
         }
         return expect.promise.all(testPromises);
@@ -302,12 +290,10 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected myStub always threw /waat/\n" +
                 "\n" +
-                "[\n" +
-                "  myStub(); at theFunction (theFileName:xx:yy)\n" +
-                "  // expected: threw /waat/\n" +
-                "  //   expected TypeError('wat') to satisfy /waat/\n" +
-                "  myStub(); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "myStub(); at theFunction (theFileName:xx:yy)\n" +
+                "// expected: threw /waat/\n" +
+                "//   expected TypeError('wat') to satisfy /waat/\n" +
+                "myStub(); at theFunction (theFileName:xx:yy)"
             );
         }
         return expect.promise.all(testPromises);
@@ -350,13 +336,11 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected increment to have calls satisfying [ { args: [ 42 ] }, { args: [ 20 ] } ]\n" +
                 "\n" +
-                "[\n" +
-                "  increment( 42 ); at theFunction (theFileName:xx:yy)\n" +
-                "  increment(\n" +
-                "    46, // should equal 20\n" +
-                "    'yadda' // should be removed\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "increment( 42 ); at theFunction (theFileName:xx:yy)\n" +
+                "increment(\n" +
+                "  46, // should equal 20\n" +
+                "  'yadda' // should be removed\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         }
 
@@ -381,14 +365,12 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected mySpy to have calls exhaustively satisfying [ { args: [ ... ] } ]\n" +
                 "\n" +
-                "[\n" +
-                "  mySpy(\n" +
-                "    {\n" +
-                "      foo: 123,\n" +
-                "      bar: 456 // should be removed\n" +
-                "    }\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "mySpy(\n" +
+                "  {\n" +
+                "    foo: 123,\n" +
+                "    bar: 456 // should be removed\n" +
+                "  }\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         }
 
@@ -418,16 +400,12 @@ describe("documentation tests", function () {
         } catch (e) {
             expect(e, "to have message",
                 "expected increment to have calls satisfying\n" +
-                "[\n" +
-                "  increment( 1 );\n" +
-                "  increment( expect.it('to be a number') );\n" +
-                "]\n" +
+                "increment( 1 );\n" +
+                "increment( expect.it('to be a number') );\n" +
                 "\n" +
-                "[\n" +
-                "  increment( 1 ); at theFunction (theFileName:xx:yy)\n" +
-                "  increment( 2 ); at theFunction (theFileName:xx:yy)\n" +
-                "  increment( 3 ); at theFunction (theFileName:xx:yy) // should be removed\n" +
-                "]"
+                "increment( 1 ); at theFunction (theFileName:xx:yy)\n" +
+                "increment( 2 ); at theFunction (theFileName:xx:yy)\n" +
+                "increment( 3 ); at theFunction (theFileName:xx:yy) // should be removed"
             );
         }
         return expect.promise.all(testPromises);
@@ -452,11 +430,9 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected mySpy was called on {}\n" +
                 "\n" +
-                "[\n" +
-                "  mySpy(); at theFunction (theFileName:xx:yy)\n" +
-                "  // expected: was called on {}\n" +
-                "  //   expected mySpy to be called with {} as this but was called with { spy: mySpy }\n" +
-                "]"
+                "mySpy(); at theFunction (theFileName:xx:yy)\n" +
+                "// expected: was called on {}\n" +
+                "//   expected mySpy to be called with {} as this but was called with { spy: mySpy }"
             );
         }
 
@@ -475,12 +451,10 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected mySpy was always called on { spy: mySpy }\n" +
                 "\n" +
-                "[\n" +
-                "  mySpy(); at theFunction (theFileName:xx:yy)\n" +
-                "  mySpy(); at theFunction (theFileName:xx:yy)\n" +
-                "  // expected: was called on { spy: mySpy }\n" +
-                "  //   expected mySpy to be called with { spy: mySpy } as this but was called with {}\n" +
-                "]"
+                "mySpy(); at theFunction (theFileName:xx:yy)\n" +
+                "mySpy(); at theFunction (theFileName:xx:yy)\n" +
+                "// expected: was called on { spy: mySpy }\n" +
+                "//   expected mySpy to be called with { spy: mySpy } as this but was called with {}"
             );
         }
         return expect.promise.all(testPromises);
@@ -515,12 +489,10 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected add was called times 2\n" +
                 "  expected\n" +
-                "  [\n" +
-                "    add( 41, 42 ); at theFunction (theFileName:xx:yy)\n" +
-                "    add( 41, 43 ); at theFunction (theFileName:xx:yy)\n" +
-                "    add( 41, 44 ); at theFunction (theFileName:xx:yy)\n" +
-                "    add( 41, 45 ); at theFunction (theFileName:xx:yy)\n" +
-                "  ]\n" +
+                "  add( 41, 42 ); at theFunction (theFileName:xx:yy)\n" +
+                "  add( 41, 43 ); at theFunction (theFileName:xx:yy)\n" +
+                "  add( 41, 44 ); at theFunction (theFileName:xx:yy)\n" +
+                "  add( 41, 45 ); at theFunction (theFileName:xx:yy)\n" +
                 "  to have length 2\n" +
                 "    expected 4 to be 2"
             );
@@ -553,14 +525,12 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected mySpy was called with 'baz', { foo: 'bar' }\n" +
                 "\n" +
-                "[\n" +
-                "  mySpy(\n" +
-                "    { foo: 'bar' }, // should equal 'baz'\n" +
-                "    'baz', // should equal { foo: 'bar' }\n" +
-                "    'qux',\n" +
-                "    'quux'\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "mySpy(\n" +
+                "  { foo: 'bar' }, // should equal 'baz'\n" +
+                "  'baz', // should equal { foo: 'bar' }\n" +
+                "  'qux',\n" +
+                "  'quux'\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         }
 
@@ -583,15 +553,13 @@ describe("documentation tests", function () {
                 "expected mySpy\n" +
                 "was always called with { foo: 'bar' }, 'baz', expect.it('to be truthy')\n" +
                 "\n" +
-                "[\n" +
-                "  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)\n" +
-                "  mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)\n" +
-                "  mySpy(\n" +
-                "    { foo: 'bar' },\n" +
-                "    'baz'\n" +
-                "    // missing: should be truthy\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)\n" +
+                "mySpy( { foo: 'bar' }, 'baz', 'qux', 'quux' ); at theFunction (theFileName:xx:yy)\n" +
+                "mySpy(\n" +
+                "  { foo: 'bar' },\n" +
+                "  'baz'\n" +
+                "  // missing: should be truthy\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         }
 
@@ -611,14 +579,12 @@ describe("documentation tests", function () {
                 "expected mySpy\n" +
                 "was called with exactly { foo: 'bar' }, 'baz', expect.it('to be truthy')\n" +
                 "\n" +
-                "[\n" +
-                "  mySpy(\n" +
-                "    { foo: 'bar' },\n" +
-                "    'baz',\n" +
-                "    'qux',\n" +
-                "    'quux' // should be removed\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "mySpy(\n" +
+                "  { foo: 'bar' },\n" +
+                "  'baz',\n" +
+                "  'qux',\n" +
+                "  'quux' // should be removed\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         }
 
@@ -641,15 +607,13 @@ describe("documentation tests", function () {
                 "expected mySpy\n" +
                 "was always called with exactly { foo: 'bar' }, 'baz', expect.it('to be truthy')\n" +
                 "\n" +
-                "[\n" +
-                "  mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)\n" +
-                "  mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)\n" +
-                "  mySpy(\n" +
-                "    { foo: 'bar' },\n" +
-                "    'baz'\n" +
-                "    // missing: should be truthy\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)\n" +
+                "mySpy( { foo: 'bar' }, 'baz', 'qux' ); at theFunction (theFileName:xx:yy)\n" +
+                "mySpy(\n" +
+                "  { foo: 'bar' },\n" +
+                "  'baz'\n" +
+                "  // missing: should be truthy\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         }
         return expect.promise.all(testPromises);
@@ -691,9 +655,7 @@ describe("documentation tests", function () {
             expect(e, "to have message",
                 "expected add was not called\n" +
                 "\n" +
-                "[\n" +
-                "  add( 42, 42 ); at theFunction (theFileName:xx:yy) // should be removed\n" +
-                "]"
+                "add( 42, 42 ); at theFunction (theFileName:xx:yy) // should be removed"
             );
         }
         return expect.promise.all(testPromises);
@@ -735,12 +697,12 @@ describe("documentation tests", function () {
             });
         } catch (e) {
             expect(e, "to have message",
-                "expected decrement( 200 ) at theFunction (theFileName:xx:yy)\n" +
+                "expected decrement( 200 ); at theFunction (theFileName:xx:yy)\n" +
                 "to satisfy { args: [ 20 ] }\n" +
                 "\n" +
                 "decrement(\n" +
                 "  200 // should equal 20\n" +
-                ") at theFunction (theFileName:xx:yy)"
+                "); at theFunction (theFileName:xx:yy)"
             );
         }
 

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -732,12 +732,14 @@ describe('unexpected-sinon', function () {
                 ]);
             }, 'to throw',
                 "expected [ spy1, spy2, die ] to have calls satisfying\n" +
-                "spy1,\n" +
-                "{ spy: spy2, args: [ 'quux' ], returned: 'yadda' },\n" +
-                "{ spy: die, threw: /cqwecqw/ },\n" +
-                "{ spy: spy1, args: [ 'yadda' ] },\n" +
-                "spy1,\n" +
-                "spy1\n" +
+                "[\n" +
+                "  spy1,\n" +
+                "  { spy: spy2, args: [ 'quux' ], returned: 'yadda' },\n" +
+                "  { spy: die, threw: /cqwecqw/ },\n" +
+                "  { spy: spy1, args: [ 'yadda' ] },\n" +
+                "  spy1,\n" +
+                "  spy1\n" +
+                "]\n" +
                 "\n" +
                 "spy1( 'foo', 'bar' ); at theFunction (theFileName:xx:yy)\n" +
                 "spy2( 'quux' ); at theFunction (theFileName:xx:yy) // returned: expected 'blah' to equal 'yadda'\n" +

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -83,9 +83,7 @@ describe('unexpected-sinon', function () {
                 spy();
                 expect(spy, "was called twice");
             }, "to throw exception", "expected spy1 was called twice\n" +
-                "  expected\n" +
-                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "  to have length 2\n" +
+                "  expected spy1(); at theFunction (theFileName:xx:yy) to have length 2\n" +
                 "    expected 1 to be 2"
             );
 
@@ -295,9 +293,11 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected [ agent005, agent006, agent007 ] given call order\n" +
                 "\n" +
-                "// missing { spy: agent005 }\n" +
-                "// missing { spy: agent006 }\n" +
-                "// missing { spy: agent007 }"
+                "[\n" +
+                "  // missing { spy: agent005 }\n" +
+                "  // missing { spy: agent006 }\n" +
+                "  // missing { spy: agent007 }\n" +
+                "]"
             );
         });
     });
@@ -781,18 +781,16 @@ describe('unexpected-sinon', function () {
                 }, 'to throw',
                     "expected spy1 to have calls exhaustively satisfying [ { args: [ ..., ... ] } ]\n" +
                     "\n" +
-                    "[\n" +
-                    "  spy1(\n" +
+                    "spy1(\n" +
+                    "  {\n" +
+                    "    foo: 123 // should be removed\n" +
+                    "  },\n" +
+                    "  [\n" +
                     "    {\n" +
-                    "      foo: 123 // should be removed\n" +
-                    "    },\n" +
-                    "    [\n" +
-                    "      {\n" +
-                    "        bar: 'quux' // should be removed\n" +
-                    "      }\n" +
-                    "    ]\n" +
-                    "  ) at theFunction (theFileName:xx:yy)\n" +
-                    "]"
+                    "      bar: 'quux' // should be removed\n" +
+                    "    }\n" +
+                    "  ]\n" +
+                    "); at theFunction (theFileName:xx:yy)"
                 );
             });
         });
@@ -880,15 +878,11 @@ describe('unexpected-sinon', function () {
                     });
                 }, 'to throw',
                     "expected spy1 to have calls satisfying\n" +
-                    "[\n" +
-                    "  spy1( 'def', false )\n" +
-                    "  spy1( 'abc', true )\n" +
-                    "]\n" +
+                    "spy1( 'def', false );\n" +
+                    "spy1( 'abc', true );\n" +
                     "\n" +
-                    "[\n" +
-                    "  // missing spy1( 'def', false )\n" +
-                    "  spy1( 'abc', true ) at theFunction (theFileName:xx:yy)\n" +
-                    "]"
+                    "// missing spy1( 'def', false );\n" +
+                    "spy1( 'abc', true ); at theFunction (theFileName:xx:yy)"
                 );
             });
 
@@ -906,19 +900,15 @@ describe('unexpected-sinon', function () {
                     });
                 }, 'to throw',
                     "expected spy1 to have calls satisfying\n" +
-                    "[\n" +
-                    "  spy1( 123, 456 )\n" +
-                    "  spy1( false )\n" +
-                    "  spy1( 234 )\n" +
-                    "  spy1( 987 )\n" +
-                    "]\n" +
+                    "spy1( 123, 456 );\n" +
+                    "spy1( false );\n" +
+                    "spy1( 234 );\n" +
+                    "spy1( 987 );\n" +
                     "\n" +
-                    "[\n" +
-                    "  spy1( 123, 456 ) at theFunction (theFileName:xx:yy)\n" +
-                    "  // missing spy1( false )\n" +
-                    "  spy1( 234 ) at theFunction (theFileName:xx:yy)\n" +
-                    "  spy1( 987 ) at theFunction (theFileName:xx:yy)\n" +
-                    "]"
+                    "spy1( 123, 456 ); at theFunction (theFileName:xx:yy)\n" +
+                    "// missing spy1( false );\n" +
+                    "spy1( 234 ); at theFunction (theFileName:xx:yy)\n" +
+                    "spy1( 987 ); at theFunction (theFileName:xx:yy)"
                 );
             });
 
@@ -936,22 +926,18 @@ describe('unexpected-sinon', function () {
                     });
                 }, 'to throw',
                     "expected spy1 to have calls satisfying\n" +
-                    "[\n" +
-                    "  spy1( 123, 456 )\n" +
-                    "  spy1( { foo: 456 } )\n" +
-                    "  spy1( 987 )\n" +
-                    "]\n" +
+                    "spy1( 123, 456 );\n" +
+                    "spy1( { foo: 456 } );\n" +
+                    "spy1( 987 );\n" +
                     "\n" +
-                    "[\n" +
-                    "  spy1( 123, 456 ) at theFunction (theFileName:xx:yy)\n" +
-                    "  spy1(\n" +
-                    "    {\n" +
-                    "      foo: 123 // should equal 456\n" +
-                    "    }\n" +
-                    "  ) at theFunction (theFileName:xx:yy)\n" +
-                    "  spy1( 456 ) at theFunction (theFileName:xx:yy) // should be removed\n" +
-                    "  spy1( 987 ) at theFunction (theFileName:xx:yy)\n" +
-                    "]"
+                    "spy1( 123, 456 ); at theFunction (theFileName:xx:yy)\n" +
+                    "spy1(\n" +
+                    "  {\n" +
+                    "    foo: 123 // should equal 456\n" +
+                    "  }\n" +
+                    "); at theFunction (theFileName:xx:yy)\n" +
+                    "spy1( 456 ); at theFunction (theFileName:xx:yy) // should be removed\n" +
+                    "spy1( 987 ); at theFunction (theFileName:xx:yy)"
                 );
             });
 

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -35,8 +35,8 @@ describe('unexpected-sinon', function () {
                 "expected spy1 was not called\n" +
                 "\n" +
                 "[\n" +
-                "  spy1( 42, { foo: 'bar' } ) at theFunction (theFileName:xx:yy) // should be removed\n" +
-                "  spy1( 'baz' ) at theFunction (theFileName:xx:yy) // should be removed\n" +
+                "  spy1( 42, { foo: 'bar' } ); at theFunction (theFileName:xx:yy) // should be removed\n" +
+                "  spy1( 'baz' ); at theFunction (theFileName:xx:yy) // should be removed\n" +
                 "]"
             );
         });
@@ -61,8 +61,8 @@ describe('unexpected-sinon', function () {
                 "expected spy1 was called once\n" +
                 "  expected\n" +
                 "  [\n" +
-                "    spy1( 42, { foo: 'bar' } ) at theFunction (theFileName:xx:yy)\n" +
-                "    spy1( 'baz' ) at theFunction (theFileName:xx:yy)\n" +
+                "    spy1( 42, { foo: 'bar' } ); at theFunction (theFileName:xx:yy)\n" +
+                "    spy1( 'baz' ); at theFunction (theFileName:xx:yy)\n" +
                 "  ]\n" +
                 "  to have length 1\n" +
                 "    expected 2 to be 1"
@@ -89,7 +89,7 @@ describe('unexpected-sinon', function () {
             }, "to throw exception", "expected spy1 was called twice\n" +
                 "  expected\n" +
                 "  [\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  ]\n" +
                 "  to have length 2\n" +
                 "    expected 1 to be 2"
@@ -103,9 +103,9 @@ describe('unexpected-sinon', function () {
                 "expected spy1 was called twice\n" +
                 "  expected\n" +
                 "  [\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
-                "    spy1( 42 ) at theFunction (theFileName:xx:yy)\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "    spy1( 42 ); at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  ]\n" +
                 "  to have length 2\n" +
                 "    expected 3 to be 2"
@@ -131,8 +131,8 @@ describe('unexpected-sinon', function () {
                 "expected spy1 was called thrice\n" +
                 "  expected\n" +
                 "  [\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  ]\n" +
                 "  to have length 3\n" +
                 "    expected 2 to be 3"
@@ -146,10 +146,10 @@ describe('unexpected-sinon', function () {
                 "expected spy1 was called thrice\n" +
                 "  expected\n" +
                 "  [\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  ]\n" +
                 "  to have length 3\n" +
                 "    expected 4 to be 3"
@@ -174,8 +174,8 @@ describe('unexpected-sinon', function () {
                 "expected spy1 was called times 3\n" +
                 "  expected\n" +
                 "  [\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  ]\n" +
                 "  to have length 3\n" +
                 "    expected 2 to be 3"
@@ -192,10 +192,10 @@ describe('unexpected-sinon', function () {
                 "expected spy1 was called times 3\n" +
                 "  expected\n" +
                 "  [\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
-                "    spy1() at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  ]\n" +
                 "  to have length 3\n" +
                 "    expected 4 to be 3"
@@ -259,12 +259,12 @@ describe('unexpected-sinon', function () {
                 "expected [ agent005, agent006, agent007, agent005, agent006, agent005 ] given call order\n" +
                 "\n" +
                 "[\n" +
-                "  agent005() at theFunction (theFileName:xx:yy)\n" +
-                "  agent006() at theFunction (theFileName:xx:yy)\n" +
-                "  agent007() at theFunction (theFileName:xx:yy)\n" +
-                "  agent005() at theFunction (theFileName:xx:yy)\n" +
-                "  agent006() at theFunction (theFileName:xx:yy)\n" +
-                "  agent007() at theFunction (theFileName:xx:yy) // spy: expected agent007 to be agent005\n" +
+                "  agent005(); at theFunction (theFileName:xx:yy)\n" +
+                "  agent006(); at theFunction (theFileName:xx:yy)\n" +
+                "  agent007(); at theFunction (theFileName:xx:yy)\n" +
+                "  agent005(); at theFunction (theFileName:xx:yy)\n" +
+                "  agent006(); at theFunction (theFileName:xx:yy)\n" +
+                "  agent007(); at theFunction (theFileName:xx:yy) // spy: expected agent007 to be agent005\n" +
                 "]"
             );
         });
@@ -282,9 +282,9 @@ describe('unexpected-sinon', function () {
                 "expected [ agent005, agent006, agent007 ] given call order\n" +
                 "\n" +
                 "[\n" +
-                "  agent005() at theFunction (theFileName:xx:yy)\n" +
-                "  agent007() at theFunction (theFileName:xx:yy) // spy: expected agent007 to be agent006\n" +
-                "  agent006() at theFunction (theFileName:xx:yy) // spy: expected agent006 to be agent007\n" +
+                "  agent005(); at theFunction (theFileName:xx:yy)\n" +
+                "  agent007(); at theFunction (theFileName:xx:yy) // spy: expected agent007 to be agent006\n" +
+                "  agent006(); at theFunction (theFileName:xx:yy) // spy: expected agent006 to be agent007\n" +
                 "]"
             );
         });
@@ -301,8 +301,8 @@ describe('unexpected-sinon', function () {
                 "expected [ agent005, agent006, agent007 ] given call order\n" +
                 "\n" +
                 "[\n" +
-                "  agent005() at theFunction (theFileName:xx:yy)\n" +
-                "  agent006() at theFunction (theFileName:xx:yy)\n" +
+                "  agent005(); at theFunction (theFileName:xx:yy)\n" +
+                "  agent006(); at theFunction (theFileName:xx:yy)\n" +
                 "  // missing { spy: agent007 }\n" +
                 "]"
             );
@@ -368,8 +368,8 @@ describe('unexpected-sinon', function () {
                 "expected spy1 was always called on { spy: spy1 }\n" +
                 "\n" +
                 "[\n" +
-                "  spy1() at theFunction (theFileName:xx:yy)\n" +
-                "  spy1() at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  // expected: was called on { spy: spy1 }\n" +
                 "  //   expected spy1 to be called with { spy: spy1 } as this but was called with null\n" +
                 "]"
@@ -408,7 +408,7 @@ describe('unexpected-sinon', function () {
                 "    'baz',\n" +
                 "    true,\n" +
                 "    false\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         });
@@ -434,8 +434,8 @@ describe('unexpected-sinon', function () {
                 "    'something else' // should equal { foo: 'bar' }\n" +
                 "    // missing 'baz'\n" +
                 "    // missing: should be truthy\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
-                "  spy1( { foo: 'bar' }, 'baz', true, false ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1( { foo: 'bar' }, 'baz', true, false ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         });
@@ -452,7 +452,7 @@ describe('unexpected-sinon', function () {
                 "    'a',\n" +
                 "    'b', // should be removed\n" +
                 "    'c'\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         });
@@ -469,7 +469,7 @@ describe('unexpected-sinon', function () {
                 "    'a',\n" +
                 "    // missing 'b'\n" +
                 "    'c'\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         });
@@ -489,7 +489,7 @@ describe('unexpected-sinon', function () {
                 "expected spy1 was never called with 'bar', expect.it('to be truthy')\n" +
                 "\n" +
                 "[\n" +
-                "  spy1( 'bar', 'true' ) at theFunction (theFileName:xx:yy)\n" +
+                "  spy1( 'bar', 'true' ); at theFunction (theFileName:xx:yy)\n" +
                 "  // should not satisfy { args: { 0: 'bar', 1: expect.it('to be truthy') } }\n" +
                 "]"
             );
@@ -504,8 +504,8 @@ describe('unexpected-sinon', function () {
                 "expected spy1 was never called with 'bar'\n" +
                 "\n" +
                 "[\n" +
-                "  spy1( 'foo' ) at theFunction (theFileName:xx:yy)\n" +
-                "  spy1( 'bar', {} ) at theFunction (theFileName:xx:yy) // should not satisfy { args: { 0: 'bar' } }\n" +
+                "  spy1( 'foo' ); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1( 'bar', {} ); at theFunction (theFileName:xx:yy) // should not satisfy { args: { 0: 'bar' } }\n" +
                 "]"
             );
         });
@@ -531,7 +531,7 @@ describe('unexpected-sinon', function () {
                 "    'bar',\n" +
                 "    'baz',\n" +
                 "    'qux' // should be removed\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         });
@@ -553,13 +553,13 @@ describe('unexpected-sinon', function () {
                 "expected spy1 was always called with exactly 'foo', 'bar', expect.it('to be truthy')\n" +
                 "\n" +
                 "[\n" +
-                "  spy1( 'foo', 'bar', 'baz' ) at theFunction (theFileName:xx:yy)\n" +
+                "  spy1( 'foo', 'bar', 'baz' ); at theFunction (theFileName:xx:yy)\n" +
                 "  spy1(\n" +
                 "    'foo',\n" +
                 "    'bar',\n" +
                 "    'baz',\n" +
                 "    'qux' // should be removed\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         });
@@ -599,15 +599,15 @@ describe('unexpected-sinon', function () {
                     "expected stub threw { name: 'TypeError' }\n" +
                     "\n" +
                     "[\n" +
-                    "  stub() at theFunction (theFileName:xx:yy) // expected: threw { name: 'TypeError' }\n" +
-                    "                                            //   expected Error() to satisfy { name: 'TypeError' }\n" +
-                    "                                            //\n" +
-                    "                                            //   {\n" +
-                    "                                            //     message: '',\n" +
-                    "                                            //     name: 'Error' // should equal 'TypeError'\n" +
-                    "                                            //                   // -Error\n" +
-                    "                                            //                   // +TypeError\n" +
-                    "                                            //   }\n" +
+                    "  stub(); at theFunction (theFileName:xx:yy) // expected: threw { name: 'TypeError' }\n" +
+                    "                                             //   expected Error() to satisfy { name: 'TypeError' }\n" +
+                    "                                             //\n" +
+                    "                                             //   {\n" +
+                    "                                             //     message: '',\n" +
+                    "                                             //     name: 'Error' // should equal 'TypeError'\n" +
+                    "                                             //                   // -Error\n" +
+                    "                                             //                   // +TypeError\n" +
+                    "                                             //   }\n" +
                     "]"
                 );
             });
@@ -632,8 +632,8 @@ describe('unexpected-sinon', function () {
                     "expected stub threw Error()\n" +
                     "\n" +
                     "[\n" +
-                    "  stub() at theFunction (theFileName:xx:yy) // expected: threw Error()\n" +
-                    "                                            //   expected TypeError() to satisfy Error()\n" +
+                    "  stub(); at theFunction (theFileName:xx:yy) // expected: threw Error()\n" +
+                    "                                             //   expected TypeError() to satisfy Error()\n" +
                     "]"
                 );
             });
@@ -666,8 +666,8 @@ describe('unexpected-sinon', function () {
                     "expected spy1 always threw\n" +
                     "\n" +
                     "[\n" +
-                    "  spy1() at theFunction (theFileName:xx:yy)\n" +
-                    "  spy1() at theFunction (theFileName:xx:yy) // expected: threw\n" +
+                    "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                    "  spy1(); at theFunction (theFileName:xx:yy) // expected: threw\n" +
                     "]"
                 );
             });
@@ -694,16 +694,16 @@ describe('unexpected-sinon', function () {
                     "expected stub always threw { name: 'Error' }\n" +
                     "\n" +
                     "[\n" +
-                    "  stub() at theFunction (theFileName:xx:yy)\n" +
-                    "  stub() at theFunction (theFileName:xx:yy) // expected: threw { name: 'Error' }\n" +
-                    "                                            //   expected TypeError() to satisfy { name: 'Error' }\n" +
-                    "                                            //\n" +
-                    "                                            //   {\n" +
-                    "                                            //     message: '',\n" +
-                    "                                            //     name: 'TypeError' // should equal 'Error'\n" +
-                    "                                            //                       // -TypeError\n" +
-                    "                                            //                       // +Error\n" +
-                    "                                            //   }\n" +
+                    "  stub(); at theFunction (theFileName:xx:yy)\n" +
+                    "  stub(); at theFunction (theFileName:xx:yy) // expected: threw { name: 'Error' }\n" +
+                    "                                             //   expected TypeError() to satisfy { name: 'Error' }\n" +
+                    "                                             //\n" +
+                    "                                             //   {\n" +
+                    "                                             //     message: '',\n" +
+                    "                                             //     name: 'TypeError' // should equal 'Error'\n" +
+                    "                                             //                       // -TypeError\n" +
+                    "                                             //                       // +Error\n" +
+                    "                                             //   }\n" +
                     "]"
                 );
             });
@@ -732,9 +732,9 @@ describe('unexpected-sinon', function () {
                     "expected stub always threw Error()\n" +
                     "\n" +
                     "[\n" +
-                    "  stub() at theFunction (theFileName:xx:yy)\n" +
-                    "  stub() at theFunction (theFileName:xx:yy) // expected: threw Error()\n" +
-                    "                                            //   expected TypeError() to satisfy Error()\n" +
+                    "  stub(); at theFunction (theFileName:xx:yy)\n" +
+                    "  stub(); at theFunction (theFileName:xx:yy) // expected: threw Error()\n" +
+                    "                                             //   expected TypeError() to satisfy Error()\n" +
                     "]"
                 );
             });
@@ -794,20 +794,20 @@ describe('unexpected-sinon', function () {
                 "]\n" +
                 "\n" +
                 "[\n" +
-                "  spy1( 'foo', 'bar' ) at theFunction (theFileName:xx:yy)\n" +
-                "  spy2( 'quux' ) at theFunction (theFileName:xx:yy) // returned: expected 'blah' to equal 'yadda'\n" +
-                "                                                    //\n" +
-                "                                                    //           -blah\n" +
-                "                                                    //           +yadda\n" +
-                "  die() at theFunction (theFileName:xx:yy) // threw: expected Error('say what') to satisfy /cqwecqw/\n" +
+                "  spy1( 'foo', 'bar' ); at theFunction (theFileName:xx:yy)\n" +
+                "  spy2( 'quux' ); at theFunction (theFileName:xx:yy) // returned: expected 'blah' to equal 'yadda'\n" +
+                "                                                     //\n" +
+                "                                                     //           -blah\n" +
+                "                                                     //           +yadda\n" +
+                "  die(); at theFunction (theFileName:xx:yy) // threw: expected Error('say what') to satisfy /cqwecqw/\n" +
                 "  spy1(\n" +
                 "    'baz' // should equal 'yadda'\n" +
                 "          //\n" +
                 "          // -baz\n" +
                 "          // +yadda\n" +
-                "  ) at theFunction (theFileName:xx:yy)\n" +
-                "  spy2( 'yadda' ) at theFunction (theFileName:xx:yy) // spy: expected spy2 to be spy1\n" +
-                "  spy1( 'baz' ) at theFunction (theFileName:xx:yy)\n" +
+                "  ); at theFunction (theFileName:xx:yy)\n" +
+                "  spy2( 'yadda' ); at theFunction (theFileName:xx:yy) // spy: expected spy2 to be spy1\n" +
+                "  spy1( 'baz' ); at theFunction (theFileName:xx:yy)\n" +
                 "]"
             );
         });
@@ -890,9 +890,9 @@ describe('unexpected-sinon', function () {
                 }, 'to throw',
                     "expected [ spy1, spy2 ] to have calls satisfying\n" +
                     "[\n" +
-                    "  spy2( 123, 456 )\n" +
-                    "  new spy1( 'abc', false )\n" +
-                    "  spy1( -99, Infinity )\n" +
+                    "  spy2( 123, 456 );\n" +
+                    "  new spy1( 'abc', false );\n" +
+                    "  spy1( -99, Infinity );\n" +
                     "]\n" +
                     "\n" +
                     "[\n" +
@@ -900,12 +900,12 @@ describe('unexpected-sinon', function () {
                     "    123,\n" +
                     "    456,\n" +
                     "    99 // should be removed\n" +
-                    "  ) at theFunction (theFileName:xx:yy)\n" +
+                    "  ); at theFunction (theFileName:xx:yy)\n" +
                     "  spy1(\n" +
                     "    'abc',\n" +
                     "    true // should equal false\n" +
-                    "  ) at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
-                    "  new spy1( -99, Infinity ) at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false\n" +
+                    "  ); at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
+                    "  new spy1( -99, Infinity ); at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false\n" +
                     "]"
                 );
             });
@@ -921,13 +921,13 @@ describe('unexpected-sinon', function () {
                 }, 'to throw',
                     "expected spy1 to have calls satisfying\n" +
                     "[\n" +
-                    "  spy1( 'abc', true )\n" +
-                    "  spy1( 'def', false )\n" +
+                    "  spy1( 'abc', true );\n" +
+                    "  spy1( 'def', false );\n" +
                     "]\n" +
                     "\n" +
                     "[\n" +
-                    "  spy1( 'abc', true ) at theFunction (theFileName:xx:yy)\n" +
-                    "  // missing spy1( 'def', false )\n" +
+                    "  spy1( 'abc', true ); at theFunction (theFileName:xx:yy)\n" +
+                    "  // missing spy1( 'def', false );\n" +
                     "]"
                 );
             });
@@ -1029,23 +1029,23 @@ describe('unexpected-sinon', function () {
                 }, 'to throw',
                     "expected spy1 to have calls satisfying\n" +
                     "[\n" +
-                    "  spy1( 'abc', expect.it('to be true') )\n" +
+                    "  spy1( 'abc', expect.it('to be true') );\n" +
                     "  spy1(\n" +
                     "    'abc',\n" +
                     "    false,\n" +
                     "    expect.it('to be a number')\n" +
                     "            .and('to be less than', 100)\n" +
-                    "  )\n" +
+                    "  );\n" +
                     "]\n" +
                     "\n" +
                     "[\n" +
-                    "  spy1( 'abc', true ) at theFunction (theFileName:xx:yy)\n" +
+                    "  spy1( 'abc', true ); at theFunction (theFileName:xx:yy)\n" +
                     "  spy1(\n" +
                     "    'abc',\n" +
                     "    false,\n" +
                     "    123 // ✓ should be a number and\n" +
                     "        // ⨯ should be less than 100\n" +
-                    "  ) at theFunction (theFileName:xx:yy)\n" +
+                    "  ); at theFunction (theFileName:xx:yy)\n" +
                     "]"
                 );
             });
@@ -1092,8 +1092,8 @@ describe('unexpected-sinon', function () {
                     "expected spy1 to have calls satisfying [ { calledWithNew: false }, { calledWithNew: true } ]\n" +
                     "\n" +
                     "[\n" +
-                    "  new spy1() at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false\n" +
-                    "  spy1() at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
+                    "  new spy1(); at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false\n" +
+                    "  spy1(); at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
                     "]"
                 );
             });

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -34,10 +34,8 @@ describe('unexpected-sinon', function () {
             }, "to throw exception",
                 "expected spy1 was not called\n" +
                 "\n" +
-                "[\n" +
-                "  spy1( 42, { foo: 'bar' } ); at theFunction (theFileName:xx:yy) // should be removed\n" +
-                "  spy1( 'baz' ); at theFunction (theFileName:xx:yy) // should be removed\n" +
-                "]"
+                "spy1( 42, { foo: 'bar' } ); at theFunction (theFileName:xx:yy) // should be removed\n" +
+                "spy1( 'baz' ); at theFunction (theFileName:xx:yy) // should be removed"
             );
         });
     });
@@ -60,10 +58,8 @@ describe('unexpected-sinon', function () {
             }, "to throw exception",
                 "expected spy1 was called once\n" +
                 "  expected\n" +
-                "  [\n" +
-                "    spy1( 42, { foo: 'bar' } ); at theFunction (theFileName:xx:yy)\n" +
-                "    spy1( 'baz' ); at theFunction (theFileName:xx:yy)\n" +
-                "  ]\n" +
+                "  spy1( 42, { foo: 'bar' } ); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1( 'baz' ); at theFunction (theFileName:xx:yy)\n" +
                 "  to have length 1\n" +
                 "    expected 2 to be 1"
             );
@@ -88,9 +84,7 @@ describe('unexpected-sinon', function () {
                 expect(spy, "was called twice");
             }, "to throw exception", "expected spy1 was called twice\n" +
                 "  expected\n" +
-                "  [\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "  ]\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  to have length 2\n" +
                 "    expected 1 to be 2"
             );
@@ -102,11 +96,9 @@ describe('unexpected-sinon', function () {
             }, "to throw exception",
                 "expected spy1 was called twice\n" +
                 "  expected\n" +
-                "  [\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "    spy1( 42 ); at theFunction (theFileName:xx:yy)\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "  ]\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1( 42 ); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  to have length 2\n" +
                 "    expected 3 to be 2"
             );
@@ -130,10 +122,8 @@ describe('unexpected-sinon', function () {
             }, "to throw exception",
                 "expected spy1 was called thrice\n" +
                 "  expected\n" +
-                "  [\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "  ]\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  to have length 3\n" +
                 "    expected 2 to be 3"
             );
@@ -145,12 +135,10 @@ describe('unexpected-sinon', function () {
             }, "to throw exception",
                 "expected spy1 was called thrice\n" +
                 "  expected\n" +
-                "  [\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "  ]\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  to have length 3\n" +
                 "    expected 4 to be 3"
             );
@@ -173,10 +161,8 @@ describe('unexpected-sinon', function () {
             }, "to throw exception",
                 "expected spy1 was called times 3\n" +
                 "  expected\n" +
-                "  [\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "  ]\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  to have length 3\n" +
                 "    expected 2 to be 3"
             );
@@ -191,12 +177,10 @@ describe('unexpected-sinon', function () {
             }, "to throw exception",
                 "expected spy1 was called times 3\n" +
                 "  expected\n" +
-                "  [\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "    spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "  ]\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
                 "  to have length 3\n" +
                 "    expected 4 to be 3"
             );
@@ -258,14 +242,12 @@ describe('unexpected-sinon', function () {
             }, 'to throw',
                 "expected [ agent005, agent006, agent007, agent005, agent006, agent005 ] given call order\n" +
                 "\n" +
-                "[\n" +
-                "  agent005(); at theFunction (theFileName:xx:yy)\n" +
-                "  agent006(); at theFunction (theFileName:xx:yy)\n" +
-                "  agent007(); at theFunction (theFileName:xx:yy)\n" +
-                "  agent005(); at theFunction (theFileName:xx:yy)\n" +
-                "  agent006(); at theFunction (theFileName:xx:yy)\n" +
-                "  agent007(); at theFunction (theFileName:xx:yy) // spy: expected agent007 to be agent005\n" +
-                "]"
+                "agent005(); at theFunction (theFileName:xx:yy)\n" +
+                "agent006(); at theFunction (theFileName:xx:yy)\n" +
+                "agent007(); at theFunction (theFileName:xx:yy)\n" +
+                "agent005(); at theFunction (theFileName:xx:yy)\n" +
+                "agent006(); at theFunction (theFileName:xx:yy)\n" +
+                "agent007(); at theFunction (theFileName:xx:yy) // spy: expected agent007 to be agent005"
             );
         });
 
@@ -281,11 +263,9 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected [ agent005, agent006, agent007 ] given call order\n" +
                 "\n" +
-                "[\n" +
-                "  agent005(); at theFunction (theFileName:xx:yy)\n" +
-                "  agent007(); at theFunction (theFileName:xx:yy) // spy: expected agent007 to be agent006\n" +
-                "  agent006(); at theFunction (theFileName:xx:yy) // spy: expected agent006 to be agent007\n" +
-                "]"
+                "agent005(); at theFunction (theFileName:xx:yy)\n" +
+                "agent007(); at theFunction (theFileName:xx:yy) // spy: expected agent007 to be agent006\n" +
+                "agent006(); at theFunction (theFileName:xx:yy) // spy: expected agent006 to be agent007"
             );
         });
 
@@ -300,11 +280,9 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected [ agent005, agent006, agent007 ] given call order\n" +
                 "\n" +
-                "[\n" +
-                "  agent005(); at theFunction (theFileName:xx:yy)\n" +
-                "  agent006(); at theFunction (theFileName:xx:yy)\n" +
-                "  // missing { spy: agent007 }\n" +
-                "]"
+                "agent005(); at theFunction (theFileName:xx:yy)\n" +
+                "agent006(); at theFunction (theFileName:xx:yy)\n" +
+                "// missing { spy: agent007 }"
             );
         });
 
@@ -317,11 +295,9 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected [ agent005, agent006, agent007 ] given call order\n" +
                 "\n" +
-                "[\n" +
-                "  // missing { spy: agent005 }\n" +
-                "  // missing { spy: agent006 }\n" +
-                "  // missing { spy: agent007 }\n" +
-                "]"
+                "// missing { spy: agent005 }\n" +
+                "// missing { spy: agent006 }\n" +
+                "// missing { spy: agent007 }"
             );
         });
     });
@@ -367,12 +343,10 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected spy1 was always called on { spy: spy1 }\n" +
                 "\n" +
-                "[\n" +
-                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "  spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "  // expected: was called on { spy: spy1 }\n" +
-                "  //   expected spy1 to be called with { spy: spy1 } as this but was called with null\n" +
-                "]"
+                "spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "// expected: was called on { spy: spy1 }\n" +
+                "//   expected spy1 to be called with { spy: spy1 } as this but was called with null"
             );
         });
     });
@@ -398,18 +372,16 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected spy1 was called with { foo: \'bar\' }, \'baz\', expect.it('to be truthy')\n" +
                 "\n" +
-                "[\n" +
-                "  spy1(\n" +
-                "    {\n" +
-                "      foo: 'baa' // should equal 'bar'\n" +
-                "                 // -baa\n" +
-                "                 // +bar\n" +
-                "    },\n" +
-                "    'baz',\n" +
-                "    true,\n" +
-                "    false\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "spy1(\n" +
+                "  {\n" +
+                "    foo: 'baa' // should equal 'bar'\n" +
+                "               // -baa\n" +
+                "               // +bar\n" +
+                "  },\n" +
+                "  'baz',\n" +
+                "  true,\n" +
+                "  false\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         });
     });
@@ -429,14 +401,12 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected spy1 was always called with { foo: 'bar' }, 'baz', expect.it('to be truthy')\n" +
                 "\n" +
-                "[\n" +
-                "  spy1(\n" +
-                "    'something else' // should equal { foo: 'bar' }\n" +
-                "    // missing 'baz'\n" +
-                "    // missing: should be truthy\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "  spy1( { foo: 'bar' }, 'baz', true, false ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "spy1(\n" +
+                "  'something else' // should equal { foo: 'bar' }\n" +
+                "  // missing 'baz'\n" +
+                "  // missing: should be truthy\n" +
+                "); at theFunction (theFileName:xx:yy)\n" +
+                "spy1( { foo: 'bar' }, 'baz', true, false ); at theFunction (theFileName:xx:yy)"
             );
         });
 
@@ -447,13 +417,11 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected spy1 was always called with exactly 'a', 'c'\n" +
                 "\n" +
-                "[\n" +
-                "  spy1(\n" +
-                "    'a',\n" +
-                "    'b', // should be removed\n" +
-                "    'c'\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "spy1(\n" +
+                "  'a',\n" +
+                "  'b', // should be removed\n" +
+                "  'c'\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         });
 
@@ -464,13 +432,11 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected spy1 was always called with exactly 'a', 'b', 'c'\n" +
                 "\n" +
-                "[\n" +
-                "  spy1(\n" +
-                "    'a',\n" +
-                "    // missing 'b'\n" +
-                "    'c'\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "spy1(\n" +
+                "  'a',\n" +
+                "  // missing 'b'\n" +
+                "  'c'\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         });
     });
@@ -488,10 +454,8 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected spy1 was never called with 'bar', expect.it('to be truthy')\n" +
                 "\n" +
-                "[\n" +
-                "  spy1( 'bar', 'true' ); at theFunction (theFileName:xx:yy)\n" +
-                "  // should not satisfy { args: { 0: 'bar', 1: expect.it('to be truthy') } }\n" +
-                "]"
+                "spy1( 'bar', 'true' ); at theFunction (theFileName:xx:yy)\n" +
+                "// should not satisfy { args: { 0: 'bar', 1: expect.it('to be truthy') } }"
             );
         });
 
@@ -503,10 +467,8 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected spy1 was never called with 'bar'\n" +
                 "\n" +
-                "[\n" +
-                "  spy1( 'foo' ); at theFunction (theFileName:xx:yy)\n" +
-                "  spy1( 'bar', {} ); at theFunction (theFileName:xx:yy) // should not satisfy { args: { 0: 'bar' } }\n" +
-                "]"
+                "spy1( 'foo' ); at theFunction (theFileName:xx:yy)\n" +
+                "spy1( 'bar', {} ); at theFunction (theFileName:xx:yy) // should not satisfy { args: { 0: 'bar' } }"
             );
         });
     });
@@ -525,14 +487,12 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected spy1 was called with exactly 'foo', 'bar', expect.it('to be truthy')\n" +
                 "\n" +
-                "[\n" +
-                "  spy1(\n" +
-                "    'foo',\n" +
-                "    'bar',\n" +
-                "    'baz',\n" +
-                "    'qux' // should be removed\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "spy1(\n" +
+                "  'foo',\n" +
+                "  'bar',\n" +
+                "  'baz',\n" +
+                "  'qux' // should be removed\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         });
     });
@@ -552,15 +512,13 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected spy1 was always called with exactly 'foo', 'bar', expect.it('to be truthy')\n" +
                 "\n" +
-                "[\n" +
-                "  spy1( 'foo', 'bar', 'baz' ); at theFunction (theFileName:xx:yy)\n" +
-                "  spy1(\n" +
-                "    'foo',\n" +
-                "    'bar',\n" +
-                "    'baz',\n" +
-                "    'qux' // should be removed\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "spy1( 'foo', 'bar', 'baz' ); at theFunction (theFileName:xx:yy)\n" +
+                "spy1(\n" +
+                "  'foo',\n" +
+                "  'bar',\n" +
+                "  'baz',\n" +
+                "  'qux' // should be removed\n" +
+                "); at theFunction (theFileName:xx:yy)"
             );
         });
     });
@@ -598,17 +556,15 @@ describe('unexpected-sinon', function () {
                 }, 'to throw exception',
                     "expected stub threw { name: 'TypeError' }\n" +
                     "\n" +
-                    "[\n" +
-                    "  stub(); at theFunction (theFileName:xx:yy) // expected: threw { name: 'TypeError' }\n" +
-                    "                                             //   expected Error() to satisfy { name: 'TypeError' }\n" +
-                    "                                             //\n" +
-                    "                                             //   {\n" +
-                    "                                             //     message: '',\n" +
-                    "                                             //     name: 'Error' // should equal 'TypeError'\n" +
-                    "                                             //                   // -Error\n" +
-                    "                                             //                   // +TypeError\n" +
-                    "                                             //   }\n" +
-                    "]"
+                    "stub(); at theFunction (theFileName:xx:yy) // expected: threw { name: 'TypeError' }\n" +
+                    "                                           //   expected Error() to satisfy { name: 'TypeError' }\n" +
+                    "                                           //\n" +
+                    "                                           //   {\n" +
+                    "                                           //     message: '',\n" +
+                    "                                           //     name: 'Error' // should equal 'TypeError'\n" +
+                    "                                           //                   // -Error\n" +
+                    "                                           //                   // +TypeError\n" +
+                    "                                           //   }"
                 );
             });
         });
@@ -631,10 +587,8 @@ describe('unexpected-sinon', function () {
                 }, 'to throw exception',
                     "expected stub threw Error()\n" +
                     "\n" +
-                    "[\n" +
-                    "  stub(); at theFunction (theFileName:xx:yy) // expected: threw Error()\n" +
-                    "                                             //   expected TypeError() to satisfy Error()\n" +
-                    "]"
+                    "stub(); at theFunction (theFileName:xx:yy) // expected: threw Error()\n" +
+                    "                                           //   expected TypeError() to satisfy Error()"
                 );
             });
         });
@@ -665,10 +619,8 @@ describe('unexpected-sinon', function () {
                 }, 'to throw exception',
                     "expected spy1 always threw\n" +
                     "\n" +
-                    "[\n" +
-                    "  spy1(); at theFunction (theFileName:xx:yy)\n" +
-                    "  spy1(); at theFunction (theFileName:xx:yy) // expected: threw\n" +
-                    "]"
+                    "spy1(); at theFunction (theFileName:xx:yy)\n" +
+                    "spy1(); at theFunction (theFileName:xx:yy) // expected: threw"
                 );
             });
         });
@@ -693,18 +645,16 @@ describe('unexpected-sinon', function () {
                 }, 'to throw exception',
                     "expected stub always threw { name: 'Error' }\n" +
                     "\n" +
-                    "[\n" +
-                    "  stub(); at theFunction (theFileName:xx:yy)\n" +
-                    "  stub(); at theFunction (theFileName:xx:yy) // expected: threw { name: 'Error' }\n" +
-                    "                                             //   expected TypeError() to satisfy { name: 'Error' }\n" +
-                    "                                             //\n" +
-                    "                                             //   {\n" +
-                    "                                             //     message: '',\n" +
-                    "                                             //     name: 'TypeError' // should equal 'Error'\n" +
-                    "                                             //                       // -TypeError\n" +
-                    "                                             //                       // +Error\n" +
-                    "                                             //   }\n" +
-                    "]"
+                    "stub(); at theFunction (theFileName:xx:yy)\n" +
+                    "stub(); at theFunction (theFileName:xx:yy) // expected: threw { name: 'Error' }\n" +
+                    "                                           //   expected TypeError() to satisfy { name: 'Error' }\n" +
+                    "                                           //\n" +
+                    "                                           //   {\n" +
+                    "                                           //     message: '',\n" +
+                    "                                           //     name: 'TypeError' // should equal 'Error'\n" +
+                    "                                           //                       // -TypeError\n" +
+                    "                                           //                       // +Error\n" +
+                    "                                           //   }"
                 );
             });
         });
@@ -731,11 +681,9 @@ describe('unexpected-sinon', function () {
                 }, 'to throw exception',
                     "expected stub always threw Error()\n" +
                     "\n" +
-                    "[\n" +
-                    "  stub(); at theFunction (theFileName:xx:yy)\n" +
-                    "  stub(); at theFunction (theFileName:xx:yy) // expected: threw Error()\n" +
-                    "                                             //   expected TypeError() to satisfy Error()\n" +
-                    "]"
+                    "stub(); at theFunction (theFileName:xx:yy)\n" +
+                    "stub(); at theFunction (theFileName:xx:yy) // expected: threw Error()\n" +
+                    "                                           //   expected TypeError() to satisfy Error()"
                 );
             });
         });
@@ -784,31 +732,27 @@ describe('unexpected-sinon', function () {
                 ]);
             }, 'to throw',
                 "expected [ spy1, spy2, die ] to have calls satisfying\n" +
-                "[\n" +
-                "  spy1,\n" +
-                "  { spy: spy2, args: [ 'quux' ], returned: 'yadda' },\n" +
-                "  { spy: die, threw: /cqwecqw/ },\n" +
-                "  { spy: spy1, args: [ 'yadda' ] },\n" +
-                "  spy1,\n" +
-                "  spy1\n" +
-                "]\n" +
+                "spy1,\n" +
+                "{ spy: spy2, args: [ 'quux' ], returned: 'yadda' },\n" +
+                "{ spy: die, threw: /cqwecqw/ },\n" +
+                "{ spy: spy1, args: [ 'yadda' ] },\n" +
+                "spy1,\n" +
+                "spy1\n" +
                 "\n" +
-                "[\n" +
-                "  spy1( 'foo', 'bar' ); at theFunction (theFileName:xx:yy)\n" +
-                "  spy2( 'quux' ); at theFunction (theFileName:xx:yy) // returned: expected 'blah' to equal 'yadda'\n" +
-                "                                                     //\n" +
-                "                                                     //           -blah\n" +
-                "                                                     //           +yadda\n" +
-                "  die(); at theFunction (theFileName:xx:yy) // threw: expected Error('say what') to satisfy /cqwecqw/\n" +
-                "  spy1(\n" +
-                "    'baz' // should equal 'yadda'\n" +
-                "          //\n" +
-                "          // -baz\n" +
-                "          // +yadda\n" +
-                "  ); at theFunction (theFileName:xx:yy)\n" +
-                "  spy2( 'yadda' ); at theFunction (theFileName:xx:yy) // spy: expected spy2 to be spy1\n" +
-                "  spy1( 'baz' ); at theFunction (theFileName:xx:yy)\n" +
-                "]"
+                "spy1( 'foo', 'bar' ); at theFunction (theFileName:xx:yy)\n" +
+                "spy2( 'quux' ); at theFunction (theFileName:xx:yy) // returned: expected 'blah' to equal 'yadda'\n" +
+                "                                                   //\n" +
+                "                                                   //           -blah\n" +
+                "                                                   //           +yadda\n" +
+                "die(); at theFunction (theFileName:xx:yy) // threw: expected Error('say what') to satisfy /cqwecqw/\n" +
+                "spy1(\n" +
+                "  'baz' // should equal 'yadda'\n" +
+                "        //\n" +
+                "        // -baz\n" +
+                "        // +yadda\n" +
+                "); at theFunction (theFileName:xx:yy)\n" +
+                "spy2( 'yadda' ); at theFunction (theFileName:xx:yy) // spy: expected spy2 to be spy1\n" +
+                "spy1( 'baz' ); at theFunction (theFileName:xx:yy)"
             );
         });
 
@@ -889,24 +833,20 @@ describe('unexpected-sinon', function () {
                     });
                 }, 'to throw',
                     "expected [ spy1, spy2 ] to have calls satisfying\n" +
-                    "[\n" +
-                    "  spy2( 123, 456 );\n" +
-                    "  new spy1( 'abc', false );\n" +
-                    "  spy1( -99, Infinity );\n" +
-                    "]\n" +
+                    "spy2( 123, 456 );\n" +
+                    "new spy1( 'abc', false );\n" +
+                    "spy1( -99, Infinity );\n" +
                     "\n" +
-                    "[\n" +
-                    "  spy2(\n" +
-                    "    123,\n" +
-                    "    456,\n" +
-                    "    99 // should be removed\n" +
-                    "  ); at theFunction (theFileName:xx:yy)\n" +
-                    "  spy1(\n" +
-                    "    'abc',\n" +
-                    "    true // should equal false\n" +
-                    "  ); at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
-                    "  new spy1( -99, Infinity ); at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false\n" +
-                    "]"
+                    "spy2(\n" +
+                    "  123,\n" +
+                    "  456,\n" +
+                    "  99 // should be removed\n" +
+                    "); at theFunction (theFileName:xx:yy)\n" +
+                    "spy1(\n" +
+                    "  'abc',\n" +
+                    "  true // should equal false\n" +
+                    "); at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
+                    "new spy1( -99, Infinity ); at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false"
                 );
             });
 
@@ -920,15 +860,11 @@ describe('unexpected-sinon', function () {
                     });
                 }, 'to throw',
                     "expected spy1 to have calls satisfying\n" +
-                    "[\n" +
-                    "  spy1( 'abc', true );\n" +
-                    "  spy1( 'def', false );\n" +
-                    "]\n" +
+                    "spy1( 'abc', true );\n" +
+                    "spy1( 'def', false );\n" +
                     "\n" +
-                    "[\n" +
-                    "  spy1( 'abc', true ); at theFunction (theFileName:xx:yy)\n" +
-                    "  // missing spy1( 'def', false );\n" +
-                    "]"
+                    "spy1( 'abc', true ); at theFunction (theFileName:xx:yy)\n" +
+                    "// missing spy1( 'def', false );"
                 );
             });
 
@@ -1028,25 +964,21 @@ describe('unexpected-sinon', function () {
                     });
                 }, 'to throw',
                     "expected spy1 to have calls satisfying\n" +
-                    "[\n" +
-                    "  spy1( 'abc', expect.it('to be true') );\n" +
-                    "  spy1(\n" +
-                    "    'abc',\n" +
-                    "    false,\n" +
-                    "    expect.it('to be a number')\n" +
-                    "            .and('to be less than', 100)\n" +
-                    "  );\n" +
-                    "]\n" +
+                    "spy1( 'abc', expect.it('to be true') );\n" +
+                    "spy1(\n" +
+                    "  'abc',\n" +
+                    "  false,\n" +
+                    "  expect.it('to be a number')\n" +
+                    "          .and('to be less than', 100)\n" +
+                    ");\n" +
                     "\n" +
-                    "[\n" +
-                    "  spy1( 'abc', true ); at theFunction (theFileName:xx:yy)\n" +
-                    "  spy1(\n" +
-                    "    'abc',\n" +
-                    "    false,\n" +
-                    "    123 // ✓ should be a number and\n" +
-                    "        // ⨯ should be less than 100\n" +
-                    "  ); at theFunction (theFileName:xx:yy)\n" +
-                    "]"
+                    "spy1( 'abc', true ); at theFunction (theFileName:xx:yy)\n" +
+                    "spy1(\n" +
+                    "  'abc',\n" +
+                    "  false,\n" +
+                    "  123 // ✓ should be a number and\n" +
+                    "      // ⨯ should be less than 100\n" +
+                    "); at theFunction (theFileName:xx:yy)"
                 );
             });
 
@@ -1091,10 +1023,8 @@ describe('unexpected-sinon', function () {
                 }, 'to throw',
                     "expected spy1 to have calls satisfying [ { calledWithNew: false }, { calledWithNew: true } ]\n" +
                     "\n" +
-                    "[\n" +
-                    "  new spy1(); at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false\n" +
-                    "  spy1(); at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
-                    "]"
+                    "new spy1(); at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false\n" +
+                    "spy1(); at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true"
                 );
             });
         });


### PR DESCRIPTION
Makes it more recognizable and copy/pastable when using ... to have calls satisfying <function>

... Unless you don't like semicolons :)