### PR TITLE
Compound assertions

### DIFF
--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -470,7 +470,7 @@
                 }
 
                 if (expect.flags.always) {
-                    return expect(calls, 'to have items satisfying', 'was called on', target);
+                    return expect(calls, 'to have items satisfying was called on', target);
                 } else {
                     var promises = calls.map(function (call) {
                        return expect.promise(function () {
@@ -483,7 +483,7 @@
                         });
 
                         if (failed) {
-                            return expect(calls, 'to have items satisfying', 'was called on', target);
+                            return expect(calls, 'to have items satisfying was called on', target);
                         }
                     });
                 }
@@ -541,7 +541,7 @@
                         return promise.isRejected();
                     });
                     if (failed) {
-                        return expect(calls, 'to have items satisfying', 'not to satisfy', { args: args });
+                        return expect(calls, 'to have items satisfying not to satisfy', { args: args });
                     }
                 });
             });
@@ -554,7 +554,7 @@
                     expect.fail('spy did not throw exception');
                 }
 
-                var args = [calls, 'to have items satisfying', 'threw'];
+                var args = [calls, 'to have items satisfying threw'];
                 if (value) {
                     args.push(value);
                 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "main": "./lib/unexpected-sinon.js",
   "peerDependencies": {
     "sinon": "*",
-    "unexpected": "10"
+    "unexpected": "^10.5.0"
   },
   "devDependencies": {
     "coveralls": "2.11.3",
@@ -38,7 +38,7 @@
     "mocha": "2.2.5",
     "serve": "*",
     "sinon": "1.16.1",
-    "unexpected": "10.3.1",
+    "unexpected": "10.5.0",
     "unexpected-documentation-site-generator": "^3.3.1"
   }
 }


### PR DESCRIPTION
Prepare for `to satisfy assertion` being deprecated.

Probably requires at least a minor version bump as Unexpected 10.5+ is now required.