### PR TITLE
Implemented 'to have a call satisfying <object|function>'.

### DIFF
--- a/documentation/assertions/spy/to-have-a-call-satisfying.md
+++ b/documentation/assertions/spy/to-have-a-call-satisfying.md
@@ -1,0 +1,82 @@
+Passes if a spy has at least one call [satisfying](http://unexpected.js.org/assertions/any/to-satisfy/) a given spec:
+
+```js
+var increment = sinon.spy(function increment(n) {
+    return n + 1;
+});
+increment(42);
+increment(46);
+expect(increment, 'to have a call satisfying', { args: [ 42 ], returnValue: 43 });
+```
+
+In case of a failing expectation you get the following output:
+
+```js
+var quux = sinon.spy().named('increment');
+quux(123, 456);
+
+expect(quux, 'to have a call satisfying', { args: [ 'foo', 456 ] });
+```
+
+```output
+expected increment to have a call satisfying { args: [ 'foo', 456 ] }
+
+increment(
+  123, // should equal 'foo'
+  456
+); at theFunction (theFileName:xx:yy)
+```
+
+Note that the individual arguments are matched with
+[`to satisfy`](http://unexpected.js.org/assertions/any/to-satisfy/)
+semantics, which means that objects are allowed to have more properties than you
+specify, so the following passes:
+
+```js
+var mySpy = sinon.spy().named('mySpy');
+mySpy({foo: 123, bar: 456});
+expect(mySpy, 'to have a call satisfying', { args: [ { foo: 123 } ] });
+```
+
+If that's not what you want, consider using the `exhaustively` flag:
+
+```js
+expect(mySpy, 'to have a call exhaustively satisfying', { args: [ { foo: 123 } ] });
+```
+
+```output
+expected mySpy to have a call exhaustively satisfying { args: [ { foo: 123 } ] }
+
+mySpy(
+  {
+    foo: 123,
+    bar: 456 // should be removed
+  }
+); at theFunction (theFileName:xx:yy)
+```
+
+You can also specify the expected call as a function that performs it:
+
+```js
+var foo = sinon.spy().named('foo');
+foo(1);
+foo(2);
+
+expect(foo, 'to have a call satisfying', function () {
+    foo(3);
+});
+```
+
+The diff will show what it would take to get every spy call to meet the spec,
+even though fixing just one of them would be sufficient to make the assertion pass:
+
+```output
+expected foo to have a call satisfying foo( 3 );
+
+foo(
+  1 // should equal 3
+); at theFunction (theFileName:xx:yy)
+foo(
+  2 // should equal 3
+); at theFunction (theFileName:xx:yy)
+```

--- a/documentation/assertions/spy/to-have-a-call-satisfying.md
+++ b/documentation/assertions/spy/to-have-a-call-satisfying.md
@@ -27,6 +27,18 @@ quux(
 ); at theFunction (theFileName:xx:yy)
 ```
 
+An array value will be interpreted as a shorthand for `{ args: ... }`:
+
+```js
+expect(quux, 'to have a call satisfying', [ 123, 456 ]);
+```
+
+Likewise for an object with only numerical properties:
+
+```js
+expect(quux, 'to have a call satisfying', { 1: 456 });
+```
+
 Note that the individual arguments are matched with
 [`to satisfy`](http://unexpected.js.org/assertions/any/to-satisfy/)
 semantics, which means that objects are allowed to have more properties than you

--- a/documentation/assertions/spy/to-have-a-call-satisfying.md
+++ b/documentation/assertions/spy/to-have-a-call-satisfying.md
@@ -12,16 +12,16 @@ expect(increment, 'to have a call satisfying', { args: [ 42 ], returnValue: 43 }
 In case of a failing expectation you get the following output:
 
 ```js
-var quux = sinon.spy().named('increment');
+var quux = sinon.spy().named('quux');
 quux(123, 456);
 
 expect(quux, 'to have a call satisfying', { args: [ 'foo', 456 ] });
 ```
 
 ```output
-expected increment to have a call satisfying { args: [ 'foo', 456 ] }
+expected quux to have a call satisfying { args: [ 'foo', 456 ] }
 
-increment(
+quux(
   123, // should equal 'foo'
   456
 ); at theFunction (theFileName:xx:yy)

--- a/documentation/assertions/spy/to-have-calls-satisfying.md
+++ b/documentation/assertions/spy/to-have-calls-satisfying.md
@@ -35,6 +35,18 @@ increment(
 ); at theFunction (theFileName:xx:yy)
 ```
 
+An array entry value will be interpreted as a shorthand for `{ args: ... }`:
+
+```js
+expect(increment, 'to have a call satisfying', [ 42 ]);
+```
+
+Likewise for an object with only numerical properties:
+
+```js
+expect(increment, 'to have a call satisfying', { 1: 'yadda' });
+```
+
 Note that the individual arguments are matched with
 [`to satisfy`](http://unexpected.js.org/assertions/any/to-satisfy/)
 semantics, which means that objects are allowed to have more properties than you

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -417,7 +417,7 @@
                         return { spy: obj };
                     } else if (Array.isArray(obj)) {
                         return { args: obj };
-                    } else {
+                    } else if (obj && typeof obj === 'object') {
                         var keys = Object.keys(obj);
                         if (
                             keys.length > 0 &&
@@ -432,6 +432,11 @@
                             seenSpies.push(obj.spy);
                         }
                         return obj;
+                    } else {
+                        expect.errorMode = 'nested';
+                        expect.fail(function () {
+                            this.error('unsupported value in spy call spec: ').appendInspected(obj);
+                        });
                     }
                 }
 

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -506,9 +506,9 @@
                 expect.errorMode = 'defaultOrNested';
                 var calls = getCalls(subject);
                 var promises = calls.map(function (call) {
-                   return expect.promise(function () {
-                       return expect(call, 'to [exhaustively] satisfy', value);
-                   });
+                    return expect.promise(function () {
+                        return expect(call, 'to [exhaustively] satisfy', value);
+                    });
                 });
                 return expect.promise.settle(promises).then(function () {
                     var failed = promises.every(function (promise) {

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -78,6 +78,54 @@
         }
     }
 
+    function recordSpyCalls(spies, fn) {
+        var originalValues = spies.map(function (spy) {
+            var originalValue = {
+                func: spy.func
+            };
+            // Temporarily override the body of the spied-on function, if any.
+            // This prevents spies with side effects from breaking while
+            // the expected calls are being recorded:
+            spy.func = function () {};
+            for (var propertyName in spy) {
+                if (spy.hasOwnProperty(propertyName) && typeof spy[propertyName] !== 'function') {
+                    if (Array.isArray(spy[propertyName])) {
+                        originalValue[propertyName] = [].concat(spy[propertyName]);
+                    } else {
+                        originalValue[propertyName] = spy[propertyName];
+                    }
+                }
+            }
+            return originalValue;
+        });
+        fn();
+        var expectedSpyCallSpecs = [];
+        spies.forEach(function (spy, i) {
+            var originalValue = originalValues[i];
+            for (var j = originalValue.args.length ; j < spy.args.length ; j += 1) {
+                var thisValue = spy.thisValues[j];
+                var calledWithNew = thisValue instanceof spy;
+                var expectedSpyCallSpec = {
+                    proxy: spy,
+                    call: spy.getCall(j),
+                    args: spy.args[j],
+                    callId: spy.callIds[j],
+                    calledWithNew: calledWithNew
+                };
+                expectedSpyCallSpec.call.getStackFrames = false;
+                expectedSpyCallSpecs.push(expectedSpyCallSpec);
+            }
+            for (var propertyName in originalValue) {
+                spy[propertyName] = originalValue[propertyName];
+            }
+        });
+        expectedSpyCallSpecs.sort(function (a, b) {
+            return a.callId - b.callId;
+        });
+
+        return expectedSpyCallSpecs;
+    }
+
     return {
         name: 'unexpected-sinon',
         installInto: function (expect) {
@@ -332,50 +380,7 @@
                 if (!Array.isArray(spies)) {
                     spies = [ spies ];
                 }
-                var originalValues = spies.map(function (spy) {
-                    var originalValue = {
-                        func: spy.func
-                    };
-                    // Temporarily override the body of the spied-on function, if any.
-                    // This prevents spies with side effects from breaking while
-                    // the expected calls are being recorded:
-                    spy.func = function () {};
-                    for (var propertyName in spy) {
-                        if (spy.hasOwnProperty(propertyName) && typeof spy[propertyName] !== 'function') {
-                            if (Array.isArray(spy[propertyName])) {
-                                originalValue[propertyName] = [].concat(spy[propertyName]);
-                            } else {
-                                originalValue[propertyName] = spy[propertyName];
-                            }
-                        }
-                    }
-                    return originalValue;
-                });
-                value();
-                var expectedSpyCallSpecs = [];
-                spies.forEach(function (spy, i) {
-                    var originalValue = originalValues[i];
-                    for (var j = originalValue.args.length ; j < spy.args.length ; j += 1) {
-                        var thisValue = spy.thisValues[j];
-                        var calledWithNew = thisValue instanceof spy;
-                        var expectedSpyCallSpec = {
-                            proxy: spy,
-                            call: spy.getCall(j),
-                            args: spy.args[j],
-                            callId: spy.callIds[j],
-                            calledWithNew: calledWithNew
-                        };
-                        expectedSpyCallSpec.call.getStackFrames = false;
-                        expectedSpyCallSpecs.push(expectedSpyCallSpec);
-                    }
-                    for (var propertyName in originalValue) {
-                        spy[propertyName] = originalValue[propertyName];
-                    }
-                });
-                expectedSpyCallSpecs.sort(function (a, b) {
-                    return a.callId - b.callId;
-                });
-
+                var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
                     expectedSpyCalls.push(expectedSpyCallSpec.call);
@@ -495,6 +500,45 @@
                         }
                     });
                 }
+            });
+
+            expect.addAssertion('<spy> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
+                expect.errorMode = 'defaultOrNested';
+                var calls = getCalls(subject);
+                var promises = calls.map(function (call) {
+                   return expect.promise(function () {
+                       return expect(call, 'to [exhaustively] satisfy', value);
+                   });
+                });
+                return expect.promise.settle(promises).then(function () {
+                    var failed = promises.every(function (promise) {
+                        return promise.isRejected();
+                    });
+
+                    if (failed) {
+                        return expect(calls, 'to have items [exhaustively] satisfying', value);
+                    }
+                });
+            });
+
+            expect.addAssertion('<spy> to have a call satisfying <function>', function (expect, subject, value) {
+                var expectedSpyCallSpecs = recordSpyCalls([subject], value);
+                var expectedSpyCalls = [];
+                expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
+                    expectedSpyCalls.push(expectedSpyCallSpec.call);
+                    delete expectedSpyCallSpec.call;
+                    delete expectedSpyCallSpec.callId;
+                });
+                if (expectedSpyCalls.length > 0) {
+                    expect.argsOutput[0] = function (output) {
+                        output.appendInspected(expectedSpyCalls);
+                    };
+                }
+                if (expectedSpyCallSpecs.length !== 1) {
+                    expect.errorMode = 'nested';
+                    expect.fail('expected the provided function to call the spy exactly once, but it called it ' + expectedSpyCallSpecs.length + ' times');
+                }
+                return expect(subject, 'to have a call satisfying', expectedSpyCallSpecs[0]);
             });
 
             expect.addAssertion('<spy> was [always] called with [exactly] <any*>', function (expect, subject) {

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -503,6 +503,16 @@
             });
 
             expect.addAssertion('<spy> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
+                var keys = Object.keys(value);
+                if (
+                    keys.length > 0 &&
+                    keys.every(function (key) {
+                        return /^[1-9]*[0-9]+$/.test(key);
+                    })
+                ) {
+                    return expect(subject, 'to have a call [exhaustively] satisfying', { args: value });
+                }
+
                 expect.errorMode = 'defaultOrNested';
                 var calls = getCalls(subject);
                 var promises = calls.map(function (call) {
@@ -519,6 +529,10 @@
                         return expect(calls, 'to have items [exhaustively] satisfying', value);
                     }
                 });
+            });
+
+            expect.addAssertion('<spy> to have a call [exhaustively] satisfying <array>', function (expect, subject, value) {
+                return expect(subject, 'to have a call [exhaustively] satisfying', { args: value });
             });
 
             expect.addAssertion('<spy> to have a call satisfying <function>', function (expect, subject, value) {

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -415,7 +415,19 @@
                     if (isSpy(obj)) {
                         seenSpies.push(obj);
                         return { spy: obj };
+                    } else if (Array.isArray(obj)) {
+                        return { args: obj };
                     } else {
+                        var keys = Object.keys(obj);
+                        if (
+                            keys.length > 0 &&
+                            keys.every(function (key) {
+                                return /^[1-9]*[0-9]+$/.test(key);
+                            })
+                        ) {
+                            return { args: obj };
+                        }
+
                         if (isSpy(obj.spy)) {
                             seenSpies.push(obj.spy);
                         }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "main": "./lib/unexpected-sinon.js",
   "peerDependencies": {
     "sinon": "*",
-    "unexpected": "^10.6.0"
+    "unexpected": "^10.8.0"
   },
   "devDependencies": {
     "coveralls": "2.11.3",
@@ -38,7 +38,7 @@
     "mocha": "2.2.5",
     "serve": "*",
     "sinon": "1.16.1",
-    "unexpected": "unexpectedjs/unexpected#feature/toHaveItemsExhaustivelySatisfying",
+    "unexpected": "10.8.0",
     "unexpected-documentation-site-generator": "^3.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mocha": "2.2.5",
     "serve": "*",
     "sinon": "1.16.1",
-    "unexpected": "10.6.0",
+    "unexpected": "unexpectedjs/unexpected#feature/toHaveItemsExhaustivelySatisfying",
     "unexpected-documentation-site-generator": "^3.3.1"
   }
 }

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -309,13 +309,13 @@ describe("documentation tests", function () {
         expect(increment, 'to have a call satisfying', { args: [ 42 ], returnValue: 43 });
 
         try {
-            var quux = sinon.spy().named('increment');
+            var quux = sinon.spy().named('quux');
             quux(123, 456);
 
             expect(quux, 'to have a call satisfying', { args: [ 'foo', 456 ] });
             expect.fail(function (output) {
                 output.error("expected:").nl();
-                output.code("var quux = sinon.spy().named('increment');").nl();
+                output.code("var quux = sinon.spy().named('quux');").nl();
                 output.code("quux(123, 456);").nl();
                 output.code("").nl();
                 output.code("expect(quux, 'to have a call satisfying', { args: [ 'foo', 456 ] });").nl();
@@ -323,14 +323,18 @@ describe("documentation tests", function () {
             });
         } catch (e) {
             expect(e, "to have message",
-                "expected increment to have a call satisfying { args: [ 'foo', 456 ] }\n" +
+                "expected quux to have a call satisfying { args: [ 'foo', 456 ] }\n" +
                 "\n" +
-                "increment(\n" +
+                "quux(\n" +
                 "  123, // should equal 'foo'\n" +
                 "  456\n" +
                 "); at theFunction (theFileName:xx:yy)"
             );
         }
+
+        expect(quux, 'to have a call satisfying', [ 123, 456 ]);
+
+        expect(quux, 'to have a call satisfying', { 1: 456 });
 
         var mySpy = sinon.spy().named('mySpy');
         mySpy({foo: 123, bar: 456});
@@ -434,6 +438,10 @@ describe("documentation tests", function () {
                 "); at theFunction (theFileName:xx:yy)"
             );
         }
+
+        expect(increment, 'to have a call satisfying', [ 42 ]);
+
+        expect(increment, 'to have a call satisfying', { 1: 'yadda' });
 
         var mySpy = sinon.spy().named('mySpy');
         mySpy({foo: 123, bar: 456});

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -299,6 +299,97 @@ describe("documentation tests", function () {
         return expect.promise.all(testPromises);
     });
 
+    it("assertions/spy/to-have-a-call-satisfying.md contains correct examples", function () {
+        var testPromises = [];
+        var increment = sinon.spy(function increment(n) {
+            return n + 1;
+        });
+        increment(42);
+        increment(46);
+        expect(increment, 'to have a call satisfying', { args: [ 42 ], returnValue: 43 });
+
+        try {
+            var quux = sinon.spy().named('increment');
+            quux(123, 456);
+
+            expect(quux, 'to have a call satisfying', { args: [ 'foo', 456 ] });
+            expect.fail(function (output) {
+                output.error("expected:").nl();
+                output.code("var quux = sinon.spy().named('increment');").nl();
+                output.code("quux(123, 456);").nl();
+                output.code("").nl();
+                output.code("expect(quux, 'to have a call satisfying', { args: [ 'foo', 456 ] });").nl();
+                output.error("to throw");
+            });
+        } catch (e) {
+            expect(e, "to have message",
+                "expected increment to have a call satisfying { args: [ 'foo', 456 ] }\n" +
+                "\n" +
+                "increment(\n" +
+                "  123, // should equal 'foo'\n" +
+                "  456\n" +
+                "); at theFunction (theFileName:xx:yy)"
+            );
+        }
+
+        var mySpy = sinon.spy().named('mySpy');
+        mySpy({foo: 123, bar: 456});
+        expect(mySpy, 'to have a call satisfying', { args: [ { foo: 123 } ] });
+
+        try {
+            expect(mySpy, 'to have a call exhaustively satisfying', { args: [ { foo: 123 } ] });
+            expect.fail(function (output) {
+                output.error("expected:").nl();
+                output.code("expect(mySpy, 'to have a call exhaustively satisfying', { args: [ { foo: 123 } ] });").nl();
+                output.error("to throw");
+            });
+        } catch (e) {
+            expect(e, "to have message",
+                "expected mySpy to have a call exhaustively satisfying { args: [ { foo: 123 } ] }\n" +
+                "\n" +
+                "mySpy(\n" +
+                "  {\n" +
+                "    foo: 123,\n" +
+                "    bar: 456 // should be removed\n" +
+                "  }\n" +
+                "); at theFunction (theFileName:xx:yy)"
+            );
+        }
+
+        try {
+            var foo = sinon.spy().named('foo');
+            foo(1);
+            foo(2);
+
+            expect(foo, 'to have a call satisfying', function () {
+                foo(3);
+            });
+            expect.fail(function (output) {
+                output.error("expected:").nl();
+                output.code("var foo = sinon.spy().named('foo');").nl();
+                output.code("foo(1);").nl();
+                output.code("foo(2);").nl();
+                output.code("").nl();
+                output.code("expect(foo, 'to have a call satisfying', function () {").nl();
+                output.code("    foo(3);").nl();
+                output.code("});").nl();
+                output.error("to throw");
+            });
+        } catch (e) {
+            expect(e, "to have message",
+                "expected foo to have a call satisfying foo( 3 );\n" +
+                "\n" +
+                "foo(\n" +
+                "  1 // should equal 3\n" +
+                "); at theFunction (theFileName:xx:yy)\n" +
+                "foo(\n" +
+                "  2 // should equal 3\n" +
+                "); at theFunction (theFileName:xx:yy)"
+            );
+        }
+        return expect.promise.all(testPromises);
+    });
+
     it("assertions/spy/to-have-calls-satisfying.md contains correct examples", function () {
         var testPromises = [];
         var increment = sinon.spy(function increment(n) {

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -700,6 +700,101 @@ describe('unexpected-sinon', function () {
         });
     });
 
+    describe('to have a call satisfying', function () {
+        describe('when passed a spec object', function () {
+            it('should succeed when a spy call satisfies the spec', function () {
+                spy(123, 456);
+                expect(spy, 'to have a call satisfying', {
+                    args: [ 123, 456 ]
+                });
+            });
+
+            it('should fail when the spy was not called at all', function () {
+                expect(function () {
+                    expect(spy, 'to have a call satisfying', {
+                        args: [ 123, 456 ]
+                    });
+                }, 'to throw',
+                    "expected spy1 to have a call satisfying { args: [ 123, 456 ] }\n" +
+                    "  expected [] to have items satisfying { args: [ 123, 456 ] }\n" +
+                    "    expected [] to be non-empty"
+                );
+            });
+
+            it('should fail when the spy was called but never with the right arguments', function () {
+                spy(456);
+                spy(567);
+                expect(function () {
+                    expect(spy, 'to have a call satisfying', {
+                        args: [ 123, 456 ]
+                    });
+                }, 'to throw',
+                    "expected spy1 to have a call satisfying { args: [ 123, 456 ] }\n" +
+                    "\n" +
+                    "spy1(\n" +
+                    "  // missing 123\n" +
+                    "  456\n" +
+                    "); at theFunction (theFileName:xx:yy)\n" +
+                    "spy1(\n" +
+                    "  567 // should equal 123\n" +
+                    "  // missing 456\n" +
+                    "); at theFunction (theFileName:xx:yy)"
+                );
+            });
+        });
+
+        describe('when passed a function that performs the expected call', function () {
+            it('should succeed when a spy call satisfies the spec', function () {
+                spy(123, 456);
+                expect(spy, 'to have a call satisfying', function () {
+                    spy(123, 456);
+                });
+            });
+
+            it('should fail if the function does not call the spy', function () {
+                expect(function () {
+                    expect(spy, 'to have a call satisfying', function () {});
+                }, 'to throw',
+                    "expected spy1 to have a call satisfying function () {}\n" +
+                    "  expected the provided function to call the spy exactly once, but it called it 0 times"
+                );
+            });
+
+            it('should fail if the function calls the spy more than once', function () {
+                expect(function () {
+                    expect(spy, 'to have a call satisfying', function () {
+                        spy(123);
+                        spy(456);
+                    });
+                }, 'to throw',
+                    "expected spy1 to have a call satisfying\n" +
+                    "spy1( 123 );\n" +
+                    "spy1( 456 );\n" +
+                    "  expected the provided function to call the spy exactly once, but it called it 2 times"
+                );
+            });
+
+            it('should fail when the spy was called but never with the right arguments', function () {
+                spy(123);
+                spy(456);
+                expect(function () {
+                    expect(spy, 'to have a call satisfying', function () {
+                        spy(789);
+                    });
+                }, 'to throw',
+                    "expected spy1 to have a call satisfying spy1( 789 );\n" +
+                    "\n" +
+                    "spy1(\n" +
+                    "  123 // should equal 789\n" +
+                    "); at theFunction (theFileName:xx:yy)\n" +
+                    "spy1(\n" +
+                    "  456 // should equal 789\n" +
+                    "); at theFunction (theFileName:xx:yy)"
+                );
+            });
+        });
+    });
+
     describe('to have calls satisfying', function () {
         it('should satisfy against a list of all calls to the specified spies', function () {
             var spy2 = sinon.spy(function spy2() {

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -994,6 +994,15 @@ describe('unexpected-sinon', function () {
             );
         });
 
+        it('should complain if a spy call spec contains an unsupported type', function () {
+            expect(function () {
+                expect(spy, 'to have calls satisfying', [123]);
+            }, 'to throw',
+                "expected spy1 to have calls satisfying [ 123 ]\n" +
+                "  unsupported value in spy call spec: 123"
+            );
+        });
+
         describe('with the exhaustively flag', function () {
             it('should fail if an object parameter contains additional properties', function () {
                 spy({foo: 123}, [{bar: 'quux'}]);

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -757,7 +757,15 @@ describe('unexpected-sinon', function () {
                             args: [ 123, { foo: 'bar' } ]
                         });
                     }, 'to throw',
-                        ''
+                        "expected spy1 to have a call exhaustively satisfying { args: [ 123, { foo: 'bar' } ] }\n" +
+                        "\n" +
+                        "spy1(\n" +
+                        "  123,\n" +
+                        "  {\n" +
+                        "    foo: 'bar',\n" +
+                        "    quux: 'baz' // should be removed\n" +
+                        "  }\n" +
+                        "); at theFunction (theFileName:xx:yy)"
                     );
                 });
             });

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -771,6 +771,56 @@ describe('unexpected-sinon', function () {
             });
         });
 
+        describe('when passed an array (shorthand for {args: ...})', function () {
+            it('should succeed', function () {
+                spy(123, { foo: 'bar' });
+                expect(spy, 'to have a call satisfying', [ 123, { foo: 'bar' } ]);
+            });
+
+            it('should fail with a diff', function () {
+                expect(function () {
+                    spy(123, { foo: 'bar' });
+                    expect(spy, 'to have a call satisfying', [ 123, { foo: 'baz' } ]);
+                }, 'to throw',
+                    "expected spy1 to have a call satisfying [ 123, { foo: 'baz' } ]\n" +
+                    "\n" +
+                    "spy1(\n" +
+                    "  123,\n" +
+                    "  {\n" +
+                    "    foo: 'bar' // should equal 'baz'\n" +
+                    "               // -bar\n" +
+                    "               // +baz\n" +
+                    "  }\n" +
+                    "); at theFunction (theFileName:xx:yy)"
+                );
+            });
+        });
+
+        describe('when passed an array with only numerical properties (shorthand for {args: ...})', function () {
+            it('should succeed', function () {
+                spy(123, { foo: 'bar' });
+                expect(spy, 'to have a call satisfying', {0: 123, 1: {foo: 'bar'}});
+            });
+
+            it('should fail with a diff', function () {
+                expect(function () {
+                    spy(123, { foo: 'bar' });
+                    expect(spy, 'to have a call satisfying', {0: 123, 1: {foo: 'baz'}});
+                }, 'to throw',
+                    "expected spy1 to have a call satisfying { 0: 123, 1: { foo: 'baz' } }\n" +
+                    "\n" +
+                    "spy1(\n" +
+                    "  123,\n" +
+                    "  {\n" +
+                    "    foo: 'bar' // should equal 'baz'\n" +
+                    "               // -bar\n" +
+                    "               // +baz\n" +
+                    "  }\n" +
+                    "); at theFunction (theFileName:xx:yy)"
+                );
+            });
+        });
+
         describe('when passed a function that performs the expected call', function () {
             it('should succeed when a spy call satisfies the spec', function () {
                 spy(123, 456);

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -741,6 +741,26 @@ describe('unexpected-sinon', function () {
                     "); at theFunction (theFileName:xx:yy)"
                 );
             });
+
+            describe('with the exhaustively flag', function () {
+                it('should succeed when a spy call satisfies the spec', function () {
+                    spy(123, { foo: 'bar' });
+                    expect(spy, 'to have a call satisfying', {
+                        args: [ 123, { foo: 'bar' } ]
+                    });
+                });
+
+                it('should fail when a spy call does not satisfy the spec only because of the "exhaustively" semantics', function () {
+                    spy(123, { foo: 'bar', quux: 'baz' });
+                    expect(function () {
+                        expect(spy, 'to have a call exhaustively satisfying', {
+                            args: [ 123, { foo: 'bar' } ]
+                        });
+                    }, 'to throw',
+                        ''
+                    );
+                });
+            });
         });
 
         describe('when passed a function that performs the expected call', function () {

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -931,6 +931,56 @@ describe('unexpected-sinon', function () {
             );
         });
 
+        describe('when passed an array entry (shorthand for {args: ...})', function () {
+            it('should succeed', function () {
+                spy(123, { foo: 'bar' });
+                expect(spy, 'to have calls satisfying', [ [ 123, { foo: 'bar' } ] ]);
+            });
+
+            it('should fail with a diff', function () {
+                expect(function () {
+                    spy(123, { foo: 'bar' });
+                    expect(spy, 'to have calls satisfying', [ [ 123, { foo: 'baz' } ] ]);
+                }, 'to throw',
+                    "expected spy1 to have calls satisfying [ [ 123, { foo: 'baz' } ] ]\n" +
+                    "\n" +
+                    "spy1(\n" +
+                    "  123,\n" +
+                    "  {\n" +
+                    "    foo: 'bar' // should equal 'baz'\n" +
+                    "               // -bar\n" +
+                    "               // +baz\n" +
+                    "  }\n" +
+                    "); at theFunction (theFileName:xx:yy)"
+                );
+            });
+        });
+
+        describe('when passed an array with only numerical properties (shorthand for {args: ...})', function () {
+            it('should succeed', function () {
+                spy(123, { foo: 'bar' });
+                expect(spy, 'to have calls satisfying', [{0: 123, 1: {foo: 'bar'}}]);
+            });
+
+            it('should fail with a diff', function () {
+                expect(function () {
+                    spy(123, { foo: 'bar' });
+                    expect(spy, 'to have calls satisfying', [{0: 123, 1: {foo: 'baz'}}]);
+                }, 'to throw',
+                    "expected spy1 to have calls satisfying [ { 0: 123, 1: { foo: 'baz' } } ]\n" +
+                    "\n" +
+                    "spy1(\n" +
+                    "  123,\n" +
+                    "  {\n" +
+                    "    foo: 'bar' // should equal 'baz'\n" +
+                    "               // -bar\n" +
+                    "               // +baz\n" +
+                    "  }\n" +
+                    "); at theFunction (theFileName:xx:yy)"
+                );
+            });
+        });
+
         it('should complain if the spy list does not contain a spy that is contained by the spec', function () {
             var spy2 = sinon.spy(function spy2() {
                 return 'blah';


### PR DESCRIPTION
Spinoff from #29.

// cc @sunesimonsen @gertsonderby @alexjeffburke @bruderstein