### PR TITLE
Add support for sinon sandboxes

### DIFF
--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -556,7 +556,7 @@
                 }
             });
 
-            expect.addAssertion('<spy> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -568,7 +568,9 @@
                 }
 
                 expect.errorMode = 'defaultOrNested';
-                var calls = getCalls(subject);
+
+                // Get a flattened array of all calls to all the specified spies:
+                var calls = Array.prototype.concat.apply([], extractSpies(subject).map(getCalls));
                 var promises = calls.map(function (call) {
                     return expect.promise(function () {
                         return expect(call, 'to [exhaustively] satisfy', value);
@@ -585,12 +587,12 @@
                 });
             });
 
-            expect.addAssertion('<spy> to have a call [exhaustively] satisfying <array>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox> to have a call [exhaustively] satisfying <array>', function (expect, subject, value) {
                 return expect(subject, 'to have a call [exhaustively] satisfying', { args: value });
             });
 
-            expect.addAssertion('<spy> to have a call satisfying <function>', function (expect, subject, value) {
-                var expectedSpyCallSpecs = recordSpyCalls([subject], value);
+            expect.addAssertion('<spy|array|sinonSandbox> to have a call satisfying <function>', function (expect, subject, value) {
+                var expectedSpyCallSpecs = recordSpyCalls(extractSpies(subject), value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
                     expectedSpyCalls.push(expectedSpyCallSpec.call);

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -420,13 +420,16 @@
                 }
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have calls [exhaustively] satisfying <function>', function (expect, subject, value) {
-                var spies = subject;
-                if (expect.subjectType.is('sinonSandbox')) {
-                    spies = subject.fakes;
-                } else if (!Array.isArray(spies)) {
-                    spies = [ spies ];
+            function extractSpies(spyOrArrayOrSinonSandbox) {
+                if (expect.findTypeOf(spyOrArrayOrSinonSandbox).is('sinonSandbox')) {
+                    return spyOrArrayOrSinonSandbox.fakes;
+                } else {
+                    return Array.isArray(spyOrArrayOrSinonSandbox) ? spyOrArrayOrSinonSandbox : [ spyOrArrayOrSinonSandbox ];
                 }
+            }
+
+            expect.addAssertion('<spy|array|sinonSandbox> to have calls [exhaustively] satisfying <function>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
@@ -441,12 +444,7 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox> to have calls [exhaustively] satisfying <array|object>', function (expect, subject, value) {
-                var spies = subject;
-                if (expect.subjectType.is('sinonSandbox')) {
-                    spies = subject.fakes;
-                } else if (!Array.isArray(spies)) {
-                    spies = [ spies ];
-                }
+                var spies = extractSpies(subject);
                 var spyCalls = [];
                 var isSeenBySpyId = {};
                 spies.forEach(function (spy) {

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -420,9 +420,11 @@
                 }
             });
 
-            expect.addAssertion('<spy|array> to have calls [exhaustively] satisfying <function>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox> to have calls [exhaustively] satisfying <function>', function (expect, subject, value) {
                 var spies = subject;
-                if (!Array.isArray(spies)) {
+                if (expect.subjectType.is('sinonSandbox')) {
+                    spies = subject.fakes;
+                } else if (!Array.isArray(spies)) {
                     spies = [ spies ];
                 }
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
@@ -438,9 +440,11 @@
                 return expect(spies, 'to have calls [exhaustively] satisfying', expectedSpyCallSpecs);
             });
 
-            expect.addAssertion('<spy|array> to have calls [exhaustively] satisfying <array|object>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox> to have calls [exhaustively] satisfying <array|object>', function (expect, subject, value) {
                 var spies = subject;
-                if (!Array.isArray(spies)) {
+                if (expect.subjectType.is('sinonSandbox')) {
+                    spies = subject.fakes;
+                } else if (!Array.isArray(spies)) {
                     spies = [ spies ];
                 }
                 var spyCalls = [];

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -422,7 +422,7 @@
 
             function extractSpies(spyOrArrayOrSinonSandbox) {
                 if (expect.findTypeOf(spyOrArrayOrSinonSandbox).is('sinonSandbox')) {
-                    return spyOrArrayOrSinonSandbox.fakes;
+                    return spyOrArrayOrSinonSandbox.fakes || [];
                 } else {
                     return Array.isArray(spyOrArrayOrSinonSandbox) ? spyOrArrayOrSinonSandbox : [ spyOrArrayOrSinonSandbox ];
                 }

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -156,6 +156,17 @@
             });
 
             expect.addType({
+                name: 'sinonSandbox',
+                base: 'object',
+                identify: function (obj) {
+                    return obj && typeof obj === 'object' && typeof obj.useFakeTimers === 'function' && typeof obj.restore === 'function';
+                },
+                inspect: function (value, depth, output, inspect) {
+                    output.jsFunctionName('sinon sandbox');
+                }
+            });
+
+            expect.addType({
                 name: 'spyCall',
                 base: 'object',
                 identify: isSpyCall,

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -1030,6 +1030,41 @@ describe('unexpected-sinon', function () {
                     "); at theFunction (theFileName:xx:yy)"
                 );
             });
+
+            describe('when passed a sinon sandbox as the subject', function () {
+                it('should succeed', function () {
+                    var sandbox = sinon.sandbox.create();
+                    var spy1 = sandbox.spy().named('spy1');
+                    var spy2 = sandbox.spy().named('spy2');
+                    spy1(123);
+                    spy2(456);
+                    return expect(sandbox, 'to have calls satisfying', [
+                        { spy: spy1, args: [ 123 ] },
+                        { spy: spy2, args: [ 456 ] }
+                    ]);
+                });
+
+                it('should fail with a diff', function () {
+                    var sandbox = sinon.sandbox.create();
+                    var spy1 = sandbox.spy().named('spy1');
+                    var spy2 = sandbox.spy().named('spy2');
+                    spy1(123);
+                    spy2(456);
+                    return expect(function () {
+                        return expect(sandbox, 'to have calls satisfying', [
+                            { spy: spy1, args: [ 123 ] },
+                            { spy: spy2, args: [ 789 ] }
+                        ]);
+                    }, 'to error with',
+                        "expected sinon sandbox to have calls satisfying [ { spy: spy1, args: [ 123 ] }, { spy: spy2, args: [ 789 ] } ]\n" +
+                        "\n" +
+                        "spy1( 123 ); at theFunction (theFileName:xx:yy)\n" +
+                        "spy2(\n" +
+                        "  456 // should equal 789\n" +
+                        "); at theFunction (theFileName:xx:yy)"
+                    );
+                });
+            });
         });
 
         describe('when passed an array with only numerical properties (shorthand for {args: ...})', function () {
@@ -1149,6 +1184,43 @@ describe('unexpected-sinon', function () {
                     "); at theFunction (theFileName:xx:yy) // calledWithNew: expected false to equal true\n" +
                     "new spy1( -99, Infinity ); at theFunction (theFileName:xx:yy) // calledWithNew: expected true to equal false"
                 );
+            });
+
+            describe('when passed a sinon sandbox as the subject', function () {
+                it('should succeed', function () {
+                    var sandbox = sinon.sandbox.create();
+                    var spy1 = sandbox.spy().named('spy1');
+                    var spy2 = sandbox.spy().named('spy2');
+                    spy1(123);
+                    spy2(456);
+                    return expect(sandbox, 'to have calls satisfying', function () {
+                        spy1(123);
+                        spy2(456);
+                    });
+                });
+
+                it('should fail with a diff', function () {
+                    var sandbox = sinon.sandbox.create();
+                    var spy1 = sandbox.spy().named('spy1');
+                    var spy2 = sandbox.spy().named('spy2');
+                    spy1(123);
+                    spy2(456);
+                    return expect(function () {
+                        return expect(sandbox, 'to have calls satisfying', function () {
+                            spy1(123);
+                            spy2(789);
+                        });
+                    }, 'to error with',
+                        "expected sinon sandbox to have calls satisfying\n" +
+                        "spy1( 123 );\n" +
+                        "spy2( 789 );\n" +
+                        "\n" +
+                        "spy1( 123 ); at theFunction (theFileName:xx:yy)\n" +
+                        "spy2(\n" +
+                        "  456 // should equal 789\n" +
+                        "); at theFunction (theFileName:xx:yy)"
+                    );
+                });
             });
 
             it('should render a spy call missing at the end', function () {

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -898,6 +898,34 @@ describe('unexpected-sinon', function () {
                 );
             });
         });
+
+        describe('when passed an array of spies as the subject', function () {
+            it('should succeed', function () {
+                var spy1 = sinon.spy().named('spy1');
+                var spy2 = sinon.spy().named('spy2');
+                spy1(123);
+                spy2(456);
+                return expect([spy1, spy2], 'to have a call satisfying', { spy: spy1, args: [ 123 ] });
+            });
+
+            it('should fail with a diff', function () {
+                var sandbox = sinon.sandbox.create();
+                var spy1 = sandbox.spy().named('spy1');
+                var spy2 = sandbox.spy().named('spy2');
+                spy1(123);
+                spy2(456);
+                return expect(function () {
+                    return expect([spy1, spy2], 'to have a call satisfying', { spy: spy1, args: [ 789 ] });
+                }, 'to error with',
+                    "expected [ spy1, spy2 ] to have a call satisfying { spy: spy1, args: [ 789 ] }\n" +
+                    "\n" +
+                    "spy1(\n" +
+                    "  123 // should equal 789\n" +
+                    "); at theFunction (theFileName:xx:yy)\n" +
+                    "spy2( 456 ); at theFunction (theFileName:xx:yy) // should be spy1( 789 );"
+                );
+            });
+        });
     });
 
     describe('to have calls satisfying', function () {

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -872,6 +872,32 @@ describe('unexpected-sinon', function () {
                 );
             });
         });
+
+        describe('when passed a sinon sandbox as the subject', function () {
+            it('should succeed', function () {
+                var sandbox = sinon.sandbox.create();
+                var spy1 = sandbox.spy().named('spy1');
+                var spy2 = sandbox.spy().named('spy2');
+                spy1(123);
+                spy2(456);
+                return expect(sandbox, 'to have a call satisfying', { spy: spy1, args: [ 123 ] });
+            });
+
+            it('should fail with a diff', function () {
+                var sandbox = sinon.sandbox.create();
+                var spy1 = sandbox.spy().named('spy1');
+                spy1(456);
+                return expect(function () {
+                    return expect(sandbox, 'to have a call satisfying', { spy: spy1, args: [ 123 ] });
+                }, 'to error with',
+                    "expected sinon sandbox to have a call satisfying { spy: spy1, args: [ 123 ] }\n" +
+                    "\n" +
+                    "spy1(\n" +
+                    "  456 // should equal 123\n" +
+                    "); at theFunction (theFileName:xx:yy)"
+                );
+            });
+        });
     });
 
     describe('to have calls satisfying', function () {


### PR DESCRIPTION
Fixes #15

I'd like to encourage the use of [sinon sandboxes](http://sinonjs.org/docs/#sandbox), mostly because they provide an easy way to restore all mocks, fake timers, fake servers etc. created during a test. That's usually both cumbersome and error prone, as it requires calling the `restore()` method of each mock/timer/fake server, and it has to happen after all async work has completed, whether or not the test failed.

Sinon sandboxes can also be used to address the problem described in #28 because the user can provide the sandbox when invoking `to have calls satisfying`, and then all stubs will automatically be "in scope". This is implemented by the second commit of this PR.

I would also like to explore adding some sugar around the creation and disposal of the sandbox object itself. The third commit is an attempt to do that by adding an `in sinon sandbox` assertion. It doesn't really fit nicely, so I'd like some feedback -- is it even worth it? Can anyone come up with a nicer API?

CC: @sunesimonsen @Munter @alexjeffburke @joelmukuthu @bruderstein