### PR TITLE
Add support for asserting on sinon.createStubInstance(Constructor)

### DIFF
--- a/documentation/assertions/spy/was-called-on.md
+++ b/documentation/assertions/spy/was-called-on.md
@@ -18,7 +18,7 @@ expected mySpy was called on {}
 
 mySpy(); at theFunction (theFileName:xx:yy)
 // expected: was called on {}
-//   expected mySpy to be called with {} as this but was called with { spy: mySpy }
+//   expected mySpy to be called with {} as this but was called with { mySpy }
 ```
 
 You can make this assertion more strict by using the `always`
@@ -37,10 +37,10 @@ expect(obj.spy, 'was always called on', obj);
 ```
 
 ```output
-expected mySpy was always called on { spy: mySpy }
+expected mySpy was always called on { mySpy }
 
 mySpy(); at theFunction (theFileName:xx:yy)
 mySpy(); at theFunction (theFileName:xx:yy)
-// expected: was called on { spy: mySpy }
-//   expected mySpy to be called with { spy: mySpy } as this but was called with {}
+// expected: was called on { mySpy }
+//   expected mySpy to be called with { mySpy } as this but was called with {}
 ```

--- a/documentation/assertions/spy/was-called-on.md
+++ b/documentation/assertions/spy/was-called-on.md
@@ -18,7 +18,7 @@ expected mySpy was called on {}
 
 mySpy(); at theFunction (theFileName:xx:yy)
 // expected: was called on {}
-//   expected mySpy to be called with {} as this but was called with { mySpy }
+//   expected mySpy to be called with {} as this but was called with { spy: mySpy }
 ```
 
 You can make this assertion more strict by using the `always`
@@ -37,10 +37,10 @@ expect(obj.spy, 'was always called on', obj);
 ```
 
 ```output
-expected mySpy was always called on { mySpy }
+expected mySpy was always called on { spy: mySpy }
 
 mySpy(); at theFunction (theFileName:xx:yy)
 mySpy(); at theFunction (theFileName:xx:yy)
-// expected: was called on { mySpy }
-//   expected mySpy to be called with { mySpy } as this but was called with {}
+// expected: was called on { spy: mySpy }
+//   expected mySpy to be called with { spy: mySpy } as this but was called with {}
 ```

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -35,9 +35,14 @@
         return (Object.prototype.toString.call(re) === '[object RegExp]');
     }
 
+    // Returns true for spies, mocks and stubs
     function isSpy(value) {
         return value && typeof value.id === 'string' &&
             /^spy#/.test(value.id);
+    }
+
+    function isStub(value) {
+        return isSpy(value) && typeof value.onCall === 'function';
     }
 
     function isSandbox(obj) {
@@ -205,7 +210,7 @@
                     if (value && typeof value === 'object' && !Array.isArray(value)) {
                         var keys = Object.keys(value);
                         return keys.length > 0 && keys.every(function (key) {
-                            return isSpy(value[key]);
+                            return isStub(value[key]);
                         });
                     }
                 },

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -149,41 +149,32 @@
         });
     }
 
+    function extractSpies(obj) {
+        var spies;
+        if (isSandbox(obj)) {
+            spies = obj.fakes || [];
+        } else if (Array.isArray(obj)) {
+            spies = [];
+            obj.forEach(function (item) {
+                Array.prototype.push.apply(spies, extractSpies(item));
+            });
+        } else if (obj && typeof obj === 'object') {
+            spies = [];
+            for (var propertyName in obj) {
+                if (isSpy(obj[propertyName])) {
+                    spies.push(obj[propertyName]);
+                }
+            }
+        } else {
+            // Assume spy
+            spies = [ obj ];
+        }
+        return spies;
+    }
+
     return {
         name: 'unexpected-sinon',
         installInto: function (expect) {
-            function extractSpiesFromSinonStubInstance(stubInstance, expect) {
-                var spies = [];
-                for (var propertyName in stubInstance) {
-                    if (isSpy(stubInstance[propertyName])) {
-                        spies.push(stubInstance[propertyName]);
-                    }
-                }
-                if (spies.length === 0) {
-                    expect.fail(function () {
-                        this.error('The passed object was not recognized as a sinon "stub instance" as it has no spies attached to it:').nl(2).appendInspected(stubInstance);
-                    });
-                }
-                return spies;
-            }
-
-            function extractSpies(obj) {
-                if (expect.findTypeOf(obj).is('sinonSandbox')) {
-                    return obj.fakes || [];
-                } else if (Array.isArray(obj)) {
-                    var spies = [];
-                    obj.forEach(function (item) {
-                        Array.prototype.push.apply(spies, extractSpies(item));
-                    });
-                    return spies;
-                } else if (obj && typeof obj === 'object') {
-                    return extractSpiesFromSinonStubInstance(obj, expect);
-                } else {
-                    // Assume spy
-                    return [ obj ];
-                }
-            }
-
             expect.addType({
                 name: 'spyCallArguments',
                 base: 'array-like',
@@ -219,7 +210,7 @@
                     }
                 },
                 inspect: function (value, depth, output, inspect) {
-                    var spies = extractSpies(value, expect);
+                    var spies = extractSpies(value);
                     var constructor = value.constructor;
                     var constructorDisplayName = constructor && constructor !== Object && constructor.name;
                     if (constructorDisplayName) {
@@ -503,8 +494,8 @@
                 }
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|object> to have calls [exhaustively] satisfying <function>', function (expect, subject, value) {
-                var spies = extractSpies(subject, expect);
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have calls [exhaustively] satisfying <function>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
@@ -518,8 +509,8 @@
                 return expect(subject, 'to have calls [exhaustively] satisfying', expectedSpyCallSpecs);
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|object> to have calls [exhaustively] satisfying <array|object>', function (expect, subject, value) {
-                var spies = extractSpies(subject, expect);
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have calls [exhaustively] satisfying <array|sinonStubInstance>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
                 var spyCalls = [];
                 var isSeenBySpyId = {};
                 spies.forEach(function (spy) {
@@ -632,8 +623,8 @@
                 }
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls [exhaustively] satisfying <object>', function (expect, subject, value) {
-                var spies = extractSpies(subject, expect);
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have no calls [exhaustively] satisfying <object>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -666,12 +657,12 @@
                 });
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls [exhaustively] satisfying <array>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have no calls [exhaustively] satisfying <array>', function (expect, subject, value) {
                 return expect(subject, 'to have no calls [exhaustively] satisfying', { args: value });
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls satisfying <function>', function (expect, subject, value) {
-                var spies = extractSpies(subject, expect);
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have no calls satisfying <function>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
@@ -691,8 +682,8 @@
                 return expect(subject, 'to have no calls satisfying', expectedSpyCallSpecs[0]);
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|object> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
-                var spies = extractSpies(subject, expect);
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -723,12 +714,12 @@
                 });
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|object> to have a call [exhaustively] satisfying <array>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have a call [exhaustively] satisfying <array>', function (expect, subject, value) {
                 return expect(subject, 'to have a call [exhaustively] satisfying', { args: value });
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|object> to have a call satisfying <function>', function (expect, subject, value) {
-                var spies = extractSpies(subject, expect);
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have a call satisfying <function>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
@@ -748,8 +739,8 @@
                 return expect(subject, 'to have a call satisfying', expectedSpyCallSpecs[0]);
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls [exhaustively] satisfying <object>', function (expect, subject, value) {
-                var spies = extractSpies(subject, expect);
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have all calls [exhaustively] satisfying <object>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -765,12 +756,12 @@
                 return expect(getCallTimeLineFromSpies(spies), 'to have items [exhaustively] satisfying', value);
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls [exhaustively] satisfying <array>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have all calls [exhaustively] satisfying <array>', function (expect, subject, value) {
                 return expect(subject, 'to have all calls [exhaustively] satisfying', { args: value });
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls satisfying <function>', function (expect, subject, value) {
-                var spies = extractSpies(subject, expect);
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have all calls satisfying <function>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -509,7 +509,7 @@
                 return expect(subject, 'to have calls [exhaustively] satisfying', expectedSpyCallSpecs);
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have calls [exhaustively] satisfying <array|sinonStubInstance>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox|sinonStubInstance> to have calls [exhaustively] satisfying <array|object>', function (expect, subject, value) {
                 var spies = extractSpies(subject);
                 var spyCalls = [];
                 var isSeenBySpyId = {};

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -428,7 +428,7 @@
                 }
             });
 
-            function extractSpiesFromSinonStubInstance(stubInstance) {
+            function extractSpiesFromSinonStubInstance(stubInstance, expect) {
                 var spies = [];
                 for (var propertyName in stubInstance) {
                     if (isSpy(stubInstance[propertyName])) {
@@ -436,7 +436,9 @@
                     }
                 }
                 if (spies.length === 0) {
-                    throw new Error('The passed object was not recognized as a sinon "stub instance" as it has no spies attached to it');
+                    expect.fail(function () {
+                        this.error('The passed object was not recognized as a sinon "stub instance" as it has no spies attached to it:').nl(2).appendInspected(stubInstance);
+                    });
                 }
                 return spies;
             }
@@ -447,7 +449,7 @@
                 } else if (Array.isArray(spyOrArrayOrSinonSandbox)) {
                     return spyOrArrayOrSinonSandbox;
                 } else if (spyOrArrayOrSinonSandbox && typeof spyOrArrayOrSinonSandbox === 'object') {
-                    return extractSpiesFromSinonStubInstance(spyOrArrayOrSinonSandbox);
+                    return extractSpiesFromSinonStubInstance(spyOrArrayOrSinonSandbox, expect);
                 } else {
                     // Assume spy
                     return [ spyOrArrayOrSinonSandbox ];
@@ -458,7 +460,7 @@
                 if (expect.subjectType.name === 'object') {
                     // Replace "stubbed instance" subject with: ClassName({spy1, spy2, spy3 /* 2 more */})
                     expect.subjectOutput = function (output) {
-                        var spies = spiesIfAvailable || extractSpies(subject);
+                        var spies = spiesIfAvailable || extractSpies(subject, expect);
                         output.jsFunctionName(subject.constructor.name || 'sinonStubInstance')
                             .text('({');
                         var width = 0;
@@ -482,7 +484,7 @@
             }
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have calls [exhaustively] satisfying <function>', function (expect, subject, value) {
-                var spies = extractSpies(subject);
+                var spies = extractSpies(subject, expect);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
@@ -498,7 +500,7 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have calls [exhaustively] satisfying <array|object>', function (expect, subject, value) {
-                var spies = extractSpies(subject);
+                var spies = extractSpies(subject, expect);
                 var spyCalls = [];
                 var isSeenBySpyId = {};
                 spies.forEach(function (spy) {
@@ -613,7 +615,7 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls [exhaustively] satisfying <object>', function (expect, subject, value) {
-                var spies = extractSpies(subject);
+                var spies = extractSpies(subject, expect);
                 overrideSubjectOutputIfStubInstance(subject, expect, spies);
                 var keys = Object.keys(value);
                 if (
@@ -653,7 +655,7 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls satisfying <function>', function (expect, subject, value) {
-                var spies = extractSpies(subject);
+                var spies = extractSpies(subject, expect);
                 overrideSubjectOutputIfStubInstance(subject, expect, spies);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
@@ -675,7 +677,7 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
-                var spies = extractSpies(subject);
+                var spies = extractSpies(subject, expect);
                 overrideSubjectOutputIfStubInstance(subject, expect, spies);
                 var keys = Object.keys(value);
                 if (
@@ -713,7 +715,7 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have a call satisfying <function>', function (expect, subject, value) {
-                var spies = extractSpies(subject);
+                var spies = extractSpies(subject, expect);
                 overrideSubjectOutputIfStubInstance(subject, expect, spies);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
@@ -735,7 +737,7 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls [exhaustively] satisfying <object>', function (expect, subject, value) {
-                var spies = extractSpies(subject);
+                var spies = extractSpies(subject, expect);
                 overrideSubjectOutputIfStubInstance(subject, expect, spies);
                 var keys = Object.keys(value);
                 if (
@@ -758,7 +760,7 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls satisfying <function>', function (expect, subject, value) {
-                var spies = extractSpies(subject);
+                var spies = extractSpies(subject, expect);
                 overrideSubjectOutputIfStubInstance(subject, expect, spies);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -460,29 +460,54 @@
                 }
             }
 
-            function overrideSubjectOutputIfStubInstance(subject, expect, spiesIfAvailable) {
+            expect.addStyle('sinonStubInstance', function (stubInstance) {
+                var spies = extractSpies(stubInstance, expect);
+                this.jsFunctionName(stubInstance.constructor.name || 'sinonStubInstance')
+                    .text('({ ');
+                var width = 0;
+                for (var i = 0 ; i < spies.length ; i += 1) {
+                    var spy = spies[i];
+                    var itemWidth = (i > 0 ? 2 : 0) + (spy.displayName ? spy.displayName.length : 4);
+                    if ((width + itemWidth) < (this.preferredWidth - 40)) {
+                        if (i > 0) {
+                            this.text(',').sp();
+                        }
+                        this.appendInspected(spy);
+                        width += itemWidth;
+                    } else {
+                        this.sp().jsComment('/* ' + (spies.length - i) + ' more */');
+                        break;
+                    }
+                }
+                this.text(' })');
+            });
+
+            function overrideSubjectOutputIfStubInstance(subject, expect) {
                 if (expect.subjectType.name === 'object') {
                     // Replace "stubbed instance" subject with: ClassName({spy1, spy2, spy3 /* 2 more */})
                     expect.subjectOutput = function (output) {
-                        var spies = spiesIfAvailable || extractSpies(subject, expect);
-                        output.jsFunctionName(subject.constructor.name || 'sinonStubInstance')
-                            .text('({ ');
-                        var width = 0;
-                        for (var i = 0 ; i < spies.length ; i += 1) {
-                            var spy = spies[i];
-                            var itemWidth = (i > 0 ? 2 : 0) + (spy.displayName ? spy.displayName.length : 4);
-                            if ((width + itemWidth) < (expect.output.preferredWidth - 40)) {
-                                if (i > 0) {
-                                    output.text(',').sp();
-                                }
-                                output.appendInspected(spy);
-                                width += itemWidth;
+                        output.sinonStubInstance(subject);
+                    };
+                } else if (
+                    expect.subjectType.name === 'array' && subject.some(function (item) {
+                        return item && !isSpy(item) && !Array.isArray(item) && typeof item === 'object';
+                    })
+                ) {
+                    expect.subjectOutput = function (output) {
+                        output.text('[').nl().indentLines();
+                        subject.forEach(function (item, i) {
+                            if (item && !isSpy(item) && !Array.isArray(item) && typeof item === 'object') {
+                                output.i().sinonStubInstance(item);
                             } else {
-                                output.sp().jsComment('/* ' + (spies.length - i) + ' more */');
-                                break;
+                                output.i().appendInspected(item);
                             }
-                        }
-                        output.text(' })');
+                            if (i < subject.length - 1) {
+                                output.text(',');
+                            }
+                            output.nl();
+                        });
+                        output.text(']');
+                        return output;
                     };
                 }
             }
@@ -499,7 +524,7 @@
                 expect.argsOutput[0] = function (output) {
                     output.appendInspected(expectedSpyCalls);
                 };
-                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                overrideSubjectOutputIfStubInstance(subject, expect);
                 return expect(subject, 'to have calls [exhaustively] satisfying', expectedSpyCallSpecs);
             });
 
@@ -517,7 +542,7 @@
                     return a.callId - b.callId;
                 });
 
-                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                overrideSubjectOutputIfStubInstance(subject, expect);
 
                 var seenSpies = [];
                 function wrapSpyInObject(obj) {
@@ -620,7 +645,7 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                overrideSubjectOutputIfStubInstance(subject, expect);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -660,7 +685,7 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls satisfying <function>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                overrideSubjectOutputIfStubInstance(subject, expect);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
@@ -682,7 +707,7 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                overrideSubjectOutputIfStubInstance(subject, expect);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -720,7 +745,7 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have a call satisfying <function>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                overrideSubjectOutputIfStubInstance(subject, expect);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
@@ -742,7 +767,7 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                overrideSubjectOutputIfStubInstance(subject, expect);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -765,7 +790,7 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls satisfying <function>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                overrideSubjectOutputIfStubInstance(subject, expect);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -428,15 +428,60 @@
                 }
             });
 
+            function extractSpiesFromSinonStubInstance(stubInstance) {
+                var spies = [];
+                for (var propertyName in stubInstance) {
+                    if (isSpy(stubInstance[propertyName])) {
+                        spies.push(stubInstance[propertyName]);
+                    }
+                }
+                if (spies.length === 0) {
+                    throw new Error('The passed object was not recognized as a sinon "stub instance" as it has no spies attached to it');
+                }
+                return spies;
+            }
+
             function extractSpies(spyOrArrayOrSinonSandbox) {
                 if (expect.findTypeOf(spyOrArrayOrSinonSandbox).is('sinonSandbox')) {
                     return spyOrArrayOrSinonSandbox.fakes || [];
+                } else if (Array.isArray(spyOrArrayOrSinonSandbox)) {
+                    return spyOrArrayOrSinonSandbox;
+                } else if (spyOrArrayOrSinonSandbox && typeof spyOrArrayOrSinonSandbox === 'object') {
+                    return extractSpiesFromSinonStubInstance(spyOrArrayOrSinonSandbox);
                 } else {
-                    return Array.isArray(spyOrArrayOrSinonSandbox) ? spyOrArrayOrSinonSandbox : [ spyOrArrayOrSinonSandbox ];
+                    // Assume spy
+                    return [ spyOrArrayOrSinonSandbox ];
                 }
             }
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have calls [exhaustively] satisfying <function>', function (expect, subject, value) {
+            function overrideSubjectOutputIfStubInstance(subject, expect, spiesIfAvailable) {
+                if (expect.subjectType.name === 'object') {
+                    // Replace "stubbed instance" subject with: ClassName({spy1, spy2, spy3 /* 2 more */})
+                    expect.subjectOutput = function (output) {
+                        var spies = spiesIfAvailable || extractSpies(subject);
+                        output.jsFunctionName(subject.constructor.name || 'sinonStubInstance')
+                            .text('({');
+                        var width = 0;
+                        for (var i = 0 ; i < spies.length ; i += 1) {
+                            var spy = spies[i];
+                            var itemWidth = (i > 0 ? 2 : 0) + (spy.displayName ? spy.displayName.length : 4);
+                            if ((width + itemWidth) < (expect.output.preferredWidth - 40)) {
+                                if (i > 0) {
+                                    output.text(',').sp();
+                                }
+                                output.appendInspected(spy);
+                                width += itemWidth;
+                            } else {
+                                output.sp().jsComment('/* ' + (spies.length - i) + ' more */');
+                                break;
+                            }
+                        }
+                        output.text('})');
+                    };
+                }
+            }
+
+            expect.addAssertion('<spy|array|sinonSandbox|object> to have calls [exhaustively] satisfying <function>', function (expect, subject, value) {
                 var spies = extractSpies(subject);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
@@ -448,10 +493,11 @@
                 expect.argsOutput[0] = function (output) {
                     output.appendInspected(expectedSpyCalls);
                 };
-                return expect(spies, 'to have calls [exhaustively] satisfying', expectedSpyCallSpecs);
+                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                return expect(subject, 'to have calls [exhaustively] satisfying', expectedSpyCallSpecs);
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have calls [exhaustively] satisfying <array|object>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox|object> to have calls [exhaustively] satisfying <array|object>', function (expect, subject, value) {
                 var spies = extractSpies(subject);
                 var spyCalls = [];
                 var isSeenBySpyId = {};
@@ -464,6 +510,8 @@
                 spyCalls.sort(function (a, b) {
                     return a.callId - b.callId;
                 });
+
+                overrideSubjectOutputIfStubInstance(subject, expect, spies);
 
                 var seenSpies = [];
                 function wrapSpyInObject(obj) {
@@ -564,8 +612,9 @@
                 }
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have no calls [exhaustively] satisfying <object>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject);
+                overrideSubjectOutputIfStubInstance(subject, expect, spies);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -598,12 +647,15 @@
                 });
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have no calls [exhaustively] satisfying <array>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls [exhaustively] satisfying <array>', function (expect, subject, value) {
+                overrideSubjectOutputIfStubInstance(subject, expect);
                 return expect(subject, 'to have no calls [exhaustively] satisfying', { args: value });
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have no calls satisfying <function>', function (expect, subject, value) {
-                var expectedSpyCallSpecs = recordSpyCalls(extractSpies(subject), value);
+            expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls satisfying <function>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
+                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
                     expectedSpyCalls.push(expectedSpyCallSpec.call);
@@ -622,8 +674,9 @@
                 return expect(subject, 'to have no calls satisfying', expectedSpyCallSpecs[0]);
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox|object> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject);
+                overrideSubjectOutputIfStubInstance(subject, expect, spies);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -654,12 +707,15 @@
                 });
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have a call [exhaustively] satisfying <array>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox|object> to have a call [exhaustively] satisfying <array>', function (expect, subject, value) {
+                overrideSubjectOutputIfStubInstance(subject, expect);
                 return expect(subject, 'to have a call [exhaustively] satisfying', { args: value });
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have a call satisfying <function>', function (expect, subject, value) {
-                var expectedSpyCallSpecs = recordSpyCalls(extractSpies(subject), value);
+            expect.addAssertion('<spy|array|sinonSandbox|object> to have a call satisfying <function>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
+                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
                     expectedSpyCalls.push(expectedSpyCallSpec.call);
@@ -678,8 +734,9 @@
                 return expect(subject, 'to have a call satisfying', expectedSpyCallSpecs[0]);
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have all calls [exhaustively] satisfying <object>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject);
+                overrideSubjectOutputIfStubInstance(subject, expect, spies);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -695,12 +752,15 @@
                 return expect(getCallTimeLineFromSpies(spies), 'to have items [exhaustively] satisfying', value);
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have all calls [exhaustively] satisfying <array>', function (expect, subject, value) {
+            expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls [exhaustively] satisfying <array>', function (expect, subject, value) {
+                overrideSubjectOutputIfStubInstance(subject, expect);
                 return expect(subject, 'to have all calls [exhaustively] satisfying', { args: value });
             });
 
-            expect.addAssertion('<spy|array|sinonSandbox> to have all calls satisfying <function>', function (expect, subject, value) {
-                var expectedSpyCallSpecs = recordSpyCalls(extractSpies(subject), value);
+            expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls satisfying <function>', function (expect, subject, value) {
+                var spies = extractSpies(subject);
+                overrideSubjectOutputIfStubInstance(subject, expect, spies);
+                var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
                     expectedSpyCalls.push(expectedSpyCallSpec.call);

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -152,6 +152,38 @@
     return {
         name: 'unexpected-sinon',
         installInto: function (expect) {
+            function extractSpiesFromSinonStubInstance(stubInstance, expect) {
+                var spies = [];
+                for (var propertyName in stubInstance) {
+                    if (isSpy(stubInstance[propertyName])) {
+                        spies.push(stubInstance[propertyName]);
+                    }
+                }
+                if (spies.length === 0) {
+                    expect.fail(function () {
+                        this.error('The passed object was not recognized as a sinon "stub instance" as it has no spies attached to it:').nl(2).appendInspected(stubInstance);
+                    });
+                }
+                return spies;
+            }
+
+            function extractSpies(obj) {
+                if (expect.findTypeOf(obj).is('sinonSandbox')) {
+                    return obj.fakes || [];
+                } else if (Array.isArray(obj)) {
+                    var spies = [];
+                    obj.forEach(function (item) {
+                        Array.prototype.push.apply(spies, extractSpies(item));
+                    });
+                    return spies;
+                } else if (obj && typeof obj === 'object') {
+                    return extractSpiesFromSinonStubInstance(obj, expect);
+                } else {
+                    // Assume spy
+                    return [ obj ];
+                }
+            }
+
             expect.addType({
                 name: 'spyCallArguments',
                 base: 'array-like',
@@ -172,6 +204,47 @@
                 identify: isSandbox,
                 inspect: function (value, depth, output, inspect) {
                     output.jsFunctionName('sinon sandbox');
+                }
+            });
+
+            expect.addType({
+                name: 'sinonStubInstance',
+                base: 'object',
+                identify: function (value) {
+                    if (value && typeof value === 'object' && !Array.isArray(value)) {
+                        var keys = Object.keys(value);
+                        return keys.length > 0 && keys.every(function (key) {
+                            return isSpy(value[key]);
+                        });
+                    }
+                },
+                inspect: function (value, depth, output, inspect) {
+                    var spies = extractSpies(value, expect);
+                    var constructor = value.constructor;
+                    var constructorDisplayName = constructor && constructor !== Object && constructor.name;
+                    if (constructorDisplayName) {
+                        output.jsFunctionName(constructor.name).text('(');
+                    }
+                    output.text('{ ');
+                    var width = 0;
+                    for (var i = 0 ; i < spies.length ; i += 1) {
+                        var spy = spies[i];
+                        var itemWidth = (i > 0 ? 2 : 0) + (spy.displayName ? spy.displayName.length : 4);
+                        if ((width + itemWidth) < (output.preferredWidth - 40)) {
+                            if (i > 0) {
+                                output.text(',').sp();
+                            }
+                            output.appendInspected(spy);
+                            width += itemWidth;
+                        } else {
+                            output.sp().jsComment('/* ' + (spies.length - i) + ' more */');
+                            break;
+                        }
+                    }
+                    output.text(' }');
+                    if (constructorDisplayName) {
+                        output.text(')');
+                    }
                 }
             });
 
@@ -430,91 +503,6 @@
                 }
             });
 
-            function extractSpiesFromSinonStubInstance(stubInstance, expect) {
-                var spies = [];
-                for (var propertyName in stubInstance) {
-                    if (isSpy(stubInstance[propertyName])) {
-                        spies.push(stubInstance[propertyName]);
-                    }
-                }
-                if (spies.length === 0) {
-                    expect.fail(function () {
-                        this.error('The passed object was not recognized as a sinon "stub instance" as it has no spies attached to it:').nl(2).appendInspected(stubInstance);
-                    });
-                }
-                return spies;
-            }
-
-            function extractSpies(obj) {
-                if (expect.findTypeOf(obj).is('sinonSandbox')) {
-                    return obj.fakes || [];
-                } else if (Array.isArray(obj)) {
-                    var spies = [];
-                    obj.forEach(function (item) {
-                        Array.prototype.push.apply(spies, extractSpies(item));
-                    });
-                    return spies;
-                } else if (obj && typeof obj === 'object') {
-                    return extractSpiesFromSinonStubInstance(obj, expect);
-                } else {
-                    // Assume spy
-                    return [ obj ];
-                }
-            }
-
-            // Unfortunately this type doesn't identify actual "in the wild"
-            // stub instances, as they don't have any sufficiently unique
-            // characteristics. It's used for casting.
-            expect.addType({
-                name: 'sinonStubInstance',
-                base: 'object',
-                identify: function (value) {
-                    return value && value._isSinonStubInstance;
-                },
-                inspect: function (value, depth, output, inspect) {
-                    var spies = extractSpies(value, expect);
-                    output.jsFunctionName(value.constructor.name || 'sinonStubInstance')
-                        .text('({ ');
-                    var width = 0;
-                    for (var i = 0 ; i < spies.length ; i += 1) {
-                        var spy = spies[i];
-                        var itemWidth = (i > 0 ? 2 : 0) + (spy.displayName ? spy.displayName.length : 4);
-                        if ((width + itemWidth) < (output.preferredWidth - 40)) {
-                            if (i > 0) {
-                                output.text(',').sp();
-                            }
-                            output.appendInspected(spy);
-                            width += itemWidth;
-                        } else {
-                            output.sp().jsComment('/* ' + (spies.length - i) + ' more */');
-                            break;
-                        }
-                    }
-                    output.text(' })');
-                }
-            });
-
-            function fixSubjectOutputForStubInstances(subject, expect) {
-                var subjectWithCastedStubInstances = (function traverse(obj) {
-                    if (Array.isArray(obj)) {
-                        return obj.map(traverse);
-                    } else if (obj && typeof obj === 'object' && !isSpy(obj) && !isSandbox(obj)) {
-                        var castedStubInstance = {_isSinonStubInstance: true, constructor: obj.constructor};
-                        Object.keys(obj).forEach(function (key) {
-                            castedStubInstance[key] = obj[key];
-                        });
-                        return castedStubInstance;
-                    } else {
-                        // spy, sandbox, or something else that we don't want to override
-                        return obj;
-                    }
-                }(subject));
-
-                expect.subjectOutput = function (output) {
-                    output.appendInspected(subjectWithCastedStubInstances);
-                };
-            }
-
             expect.addAssertion('<spy|array|sinonSandbox|object> to have calls [exhaustively] satisfying <function>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
@@ -527,7 +515,6 @@
                 expect.argsOutput[0] = function (output) {
                     output.appendInspected(expectedSpyCalls);
                 };
-                fixSubjectOutputForStubInstances(subject, expect);
                 return expect(subject, 'to have calls [exhaustively] satisfying', expectedSpyCallSpecs);
             });
 
@@ -545,7 +532,6 @@
                     return a.callId - b.callId;
                 });
 
-                fixSubjectOutputForStubInstances(subject, expect);
 
                 var seenSpies = [];
                 function wrapSpyInObject(obj) {
@@ -648,7 +634,6 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                fixSubjectOutputForStubInstances(subject, expect);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -682,13 +667,11 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls [exhaustively] satisfying <array>', function (expect, subject, value) {
-                fixSubjectOutputForStubInstances(subject, expect);
                 return expect(subject, 'to have no calls [exhaustively] satisfying', { args: value });
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls satisfying <function>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                fixSubjectOutputForStubInstances(subject, expect);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
@@ -710,7 +693,6 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                fixSubjectOutputForStubInstances(subject, expect);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -742,13 +724,11 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have a call [exhaustively] satisfying <array>', function (expect, subject, value) {
-                fixSubjectOutputForStubInstances(subject, expect);
                 return expect(subject, 'to have a call [exhaustively] satisfying', { args: value });
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have a call satisfying <function>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                fixSubjectOutputForStubInstances(subject, expect);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
@@ -770,7 +750,6 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                fixSubjectOutputForStubInstances(subject, expect);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -787,13 +766,11 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls [exhaustively] satisfying <array>', function (expect, subject, value) {
-                fixSubjectOutputForStubInstances(subject, expect);
                 return expect(subject, 'to have all calls [exhaustively] satisfying', { args: value });
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls satisfying <function>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                fixSubjectOutputForStubInstances(subject, expect);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -462,7 +462,7 @@
                     expect.subjectOutput = function (output) {
                         var spies = spiesIfAvailable || extractSpies(subject, expect);
                         output.jsFunctionName(subject.constructor.name || 'sinonStubInstance')
-                            .text('({');
+                            .text('({ ');
                         var width = 0;
                         for (var i = 0 ; i < spies.length ; i += 1) {
                             var spy = spies[i];
@@ -478,7 +478,7 @@
                                 break;
                             }
                         }
-                        output.text('})');
+                        output.text(' })');
                     };
                 }
             }

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -40,6 +40,10 @@
             /^spy#/.test(value.id);
     }
 
+    function isSandbox(obj) {
+        return obj && typeof obj === 'object' && typeof obj.useFakeTimers === 'function' && typeof obj.restore === 'function';
+    }
+
     function isSpyCall(value) {
         return value && isSpy(value.proxy);
     }
@@ -165,9 +169,7 @@
             expect.addType({
                 name: 'sinonSandbox',
                 base: 'object',
-                identify: function (obj) {
-                    return obj && typeof obj === 'object' && typeof obj.useFakeTimers === 'function' && typeof obj.restore === 'function';
-                },
+                identify: isSandbox,
                 inspect: function (value, depth, output, inspect) {
                     output.jsFunctionName('sinon sandbox');
                 }
@@ -460,56 +462,57 @@
                 }
             }
 
-            expect.addStyle('sinonStubInstance', function (stubInstance) {
-                var spies = extractSpies(stubInstance, expect);
-                this.jsFunctionName(stubInstance.constructor.name || 'sinonStubInstance')
-                    .text('({ ');
-                var width = 0;
-                for (var i = 0 ; i < spies.length ; i += 1) {
-                    var spy = spies[i];
-                    var itemWidth = (i > 0 ? 2 : 0) + (spy.displayName ? spy.displayName.length : 4);
-                    if ((width + itemWidth) < (this.preferredWidth - 40)) {
-                        if (i > 0) {
-                            this.text(',').sp();
+            // Unfortunately this type doesn't identify actual "in the wild"
+            // stub instances, as they don't have any sufficiently unique
+            // characteristics. It's used for casting.
+            expect.addType({
+                name: 'sinonStubInstance',
+                base: 'object',
+                identify: function (value) {
+                    return value && value._isSinonStubInstance;
+                },
+                inspect: function (value, depth, output, inspect) {
+                    var spies = extractSpies(value, expect);
+                    output.jsFunctionName(value.constructor.name || 'sinonStubInstance')
+                        .text('({ ');
+                    var width = 0;
+                    for (var i = 0 ; i < spies.length ; i += 1) {
+                        var spy = spies[i];
+                        var itemWidth = (i > 0 ? 2 : 0) + (spy.displayName ? spy.displayName.length : 4);
+                        if ((width + itemWidth) < (output.preferredWidth - 40)) {
+                            if (i > 0) {
+                                output.text(',').sp();
+                            }
+                            output.appendInspected(spy);
+                            width += itemWidth;
+                        } else {
+                            output.sp().jsComment('/* ' + (spies.length - i) + ' more */');
+                            break;
                         }
-                        this.appendInspected(spy);
-                        width += itemWidth;
-                    } else {
-                        this.sp().jsComment('/* ' + (spies.length - i) + ' more */');
-                        break;
                     }
+                    output.text(' })');
                 }
-                this.text(' })');
             });
 
-            function overrideSubjectOutputIfStubInstance(subject, expect) {
-                if (expect.subjectType.name === 'object') {
-                    // Replace "stubbed instance" subject with: ClassName({spy1, spy2, spy3 /* 2 more */})
-                    expect.subjectOutput = function (output) {
-                        output.sinonStubInstance(subject);
-                    };
-                } else if (
-                    expect.subjectType.name === 'array' && subject.some(function (item) {
-                        return item && !isSpy(item) && !Array.isArray(item) && typeof item === 'object';
-                    })
-                ) {
-                    expect.subjectOutput = function (output) {
-                        output.text('[').nl().indentLines();
-                        subject.forEach(function (item, i) {
-                            if (item && !isSpy(item) && !Array.isArray(item) && typeof item === 'object') {
-                                output.i().sinonStubInstance(item);
-                            } else {
-                                output.i().appendInspected(item);
-                            }
-                            if (i < subject.length - 1) {
-                                output.text(',');
-                            }
-                            output.nl();
+            function fixSubjectOutputForStubInstances(subject, expect) {
+                var subjectWithCastedStubInstances = (function traverse(obj) {
+                    if (Array.isArray(obj)) {
+                        return obj.map(traverse);
+                    } else if (obj && typeof obj === 'object' && !isSpy(obj) && !isSandbox(obj)) {
+                        var castedStubInstance = {_isSinonStubInstance: true, constructor: obj.constructor};
+                        Object.keys(obj).forEach(function (key) {
+                            castedStubInstance[key] = obj[key];
                         });
-                        output.text(']');
-                        return output;
-                    };
-                }
+                        return castedStubInstance;
+                    } else {
+                        // spy, sandbox, or something else that we don't want to override
+                        return obj;
+                    }
+                }(subject));
+
+                expect.subjectOutput = function (output) {
+                    output.appendInspected(subjectWithCastedStubInstances);
+                };
             }
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have calls [exhaustively] satisfying <function>', function (expect, subject, value) {
@@ -524,7 +527,7 @@
                 expect.argsOutput[0] = function (output) {
                     output.appendInspected(expectedSpyCalls);
                 };
-                overrideSubjectOutputIfStubInstance(subject, expect);
+                fixSubjectOutputForStubInstances(subject, expect);
                 return expect(subject, 'to have calls [exhaustively] satisfying', expectedSpyCallSpecs);
             });
 
@@ -542,7 +545,7 @@
                     return a.callId - b.callId;
                 });
 
-                overrideSubjectOutputIfStubInstance(subject, expect);
+                fixSubjectOutputForStubInstances(subject, expect);
 
                 var seenSpies = [];
                 function wrapSpyInObject(obj) {
@@ -645,7 +648,7 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect);
+                fixSubjectOutputForStubInstances(subject, expect);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -679,13 +682,13 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls [exhaustively] satisfying <array>', function (expect, subject, value) {
-                overrideSubjectOutputIfStubInstance(subject, expect);
+                fixSubjectOutputForStubInstances(subject, expect);
                 return expect(subject, 'to have no calls [exhaustively] satisfying', { args: value });
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have no calls satisfying <function>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect);
+                fixSubjectOutputForStubInstances(subject, expect);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
@@ -707,7 +710,7 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have a call [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect);
+                fixSubjectOutputForStubInstances(subject, expect);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -739,13 +742,13 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have a call [exhaustively] satisfying <array>', function (expect, subject, value) {
-                overrideSubjectOutputIfStubInstance(subject, expect);
+                fixSubjectOutputForStubInstances(subject, expect);
                 return expect(subject, 'to have a call [exhaustively] satisfying', { args: value });
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have a call satisfying <function>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect);
+                fixSubjectOutputForStubInstances(subject, expect);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {
@@ -767,7 +770,7 @@
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls [exhaustively] satisfying <object>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect);
+                fixSubjectOutputForStubInstances(subject, expect);
                 var keys = Object.keys(value);
                 if (
                     keys.length > 0 &&
@@ -784,13 +787,13 @@
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls [exhaustively] satisfying <array>', function (expect, subject, value) {
-                overrideSubjectOutputIfStubInstance(subject, expect);
+                fixSubjectOutputForStubInstances(subject, expect);
                 return expect(subject, 'to have all calls [exhaustively] satisfying', { args: value });
             });
 
             expect.addAssertion('<spy|array|sinonSandbox|object> to have all calls satisfying <function>', function (expect, subject, value) {
                 var spies = extractSpies(subject, expect);
-                overrideSubjectOutputIfStubInstance(subject, expect);
+                fixSubjectOutputForStubInstances(subject, expect);
                 var expectedSpyCallSpecs = recordSpyCalls(spies, value);
                 var expectedSpyCalls = [];
                 expectedSpyCallSpecs.forEach(function (expectedSpyCallSpec) {

--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -443,16 +443,20 @@
                 return spies;
             }
 
-            function extractSpies(spyOrArrayOrSinonSandbox) {
-                if (expect.findTypeOf(spyOrArrayOrSinonSandbox).is('sinonSandbox')) {
-                    return spyOrArrayOrSinonSandbox.fakes || [];
-                } else if (Array.isArray(spyOrArrayOrSinonSandbox)) {
-                    return spyOrArrayOrSinonSandbox;
-                } else if (spyOrArrayOrSinonSandbox && typeof spyOrArrayOrSinonSandbox === 'object') {
-                    return extractSpiesFromSinonStubInstance(spyOrArrayOrSinonSandbox, expect);
+            function extractSpies(obj) {
+                if (expect.findTypeOf(obj).is('sinonSandbox')) {
+                    return obj.fakes || [];
+                } else if (Array.isArray(obj)) {
+                    var spies = [];
+                    obj.forEach(function (item) {
+                        Array.prototype.push.apply(spies, extractSpies(item));
+                    });
+                    return spies;
+                } else if (obj && typeof obj === 'object') {
+                    return extractSpiesFromSinonStubInstance(obj, expect);
                 } else {
                     // Assume spy
-                    return [ spyOrArrayOrSinonSandbox ];
+                    return [ obj ];
                 }
             }
 

--- a/test/monkeyPatchSinonStackFrames.js
+++ b/test/monkeyPatchSinonStackFrames.js
@@ -40,7 +40,7 @@
 
     ['spy', 'stub'].forEach(function (name) {
         var orig = sinon[name];
-        sinon[name] = function () {
+        sinon[name] = function () { // ...
             var result = orig.apply(this, arguments);
             if (isSpy(result)) {
                 patchSpy(result);
@@ -49,4 +49,15 @@
         };
         sinon[name].create = orig.create;
     });
+
+    var origCreateStubInstance = sinon.createStubInstance;
+    sinon.createStubInstance = function () { // ...
+        var instance = origCreateStubInstance.apply(this, arguments);
+        for (var propertyName in instance) {
+            if (isSpy(instance[propertyName])) {
+                patchSpy(instance[propertyName]);
+            }
+        }
+        return instance;
+    };
 }));

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -1,4 +1,16 @@
 /*global describe, it, beforeEach, sinon, unexpected*/
+
+// Bogus class to be used with sinon.createStubInstance:
+function MyClass() {
+    throw new Error('oh no');
+}
+MyClass.prototype.foo = function () {
+    throw new Error('oh no');
+};
+MyClass.prototype.bar = function () {
+    throw new Error('oh no');
+};
+
 describe('unexpected-sinon', function () {
     var expect, spy;
 
@@ -520,6 +532,34 @@ describe('unexpected-sinon', function () {
             );
         });
 
+        describe('when passed a sinon stub instance as the subject', function () {
+            it('should succeed', function () {
+                var stubInstance = sinon.createStubInstance(MyClass);
+                stubInstance.foo(123);
+                return expect(stubInstance, 'to have no calls satisfying', function () {
+                    stubInstance.foo(456);
+                });
+            });
+
+            it('should fail with a diff', function () {
+                var stubInstance = sinon.createStubInstance(MyClass);
+                stubInstance.foo(123);
+                stubInstance.bar(456);
+                stubInstance.foo(123);
+                return expect(function () {
+                    return expect(stubInstance, 'to have no calls satisfying', function () {
+                        stubInstance.bar(456);
+                    });
+                }, 'to error with',
+                    "expected MyClass({foo, bar}) to have no calls satisfying bar( 456 );\n" +
+                    "\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy)\n" +
+                    "bar( 456 ); at theFunction (theFileName:xx:yy) // should be removed\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy)"
+                );
+            });
+        });
+
         describe('when passed a spec object', function () {
             it('should succeed when no spy call satisfies the spec', function () {
                 spy(123, 456);
@@ -908,6 +948,36 @@ describe('unexpected-sinon', function () {
     });
 
     describe('to have a call satisfying', function () {
+        describe('when passed a sinon stub instance as the subject', function () {
+            it('should succeed', function () {
+                var stubInstance = sinon.createStubInstance(MyClass);
+                stubInstance.foo(123);
+                stubInstance.foo(456);
+                return expect(stubInstance, 'to have a call satisfying', function () {
+                    stubInstance.foo(123);
+                });
+            });
+
+            it('should fail with a diff', function () {
+                var stubInstance = sinon.createStubInstance(MyClass);
+                stubInstance.foo(123);
+                stubInstance.bar(456);
+                stubInstance.foo(123);
+                return expect(function () {
+                    return expect(stubInstance, 'to have a call satisfying', function () {
+                        stubInstance.bar(789);
+                    });
+                }, 'to error with',
+                    "expected MyClass({foo, bar}) to have a call satisfying bar( 789 );\n" +
+                    "\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy) // should be bar( 789 );\n" +
+                    "bar(\n" +
+                    "  456 // should equal 789\n" +
+                    "); at theFunction (theFileName:xx:yy)\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy) // should be bar( 789 );"
+                );
+            });
+        });
         describe('when passed a spec object', function () {
             it('should succeed when a spy call satisfies the spec', function () {
                 spy(123, 456);
@@ -1137,6 +1207,35 @@ describe('unexpected-sinon', function () {
     });
 
     describe('to have all calls satisfying', function () {
+        describe('when passed a sinon stub instance as the subject', function () {
+            it('should succeed', function () {
+                var stubInstance = sinon.createStubInstance(MyClass);
+                stubInstance.foo(123);
+                stubInstance.foo(123);
+                return expect(stubInstance, 'to have all calls satisfying', function () {
+                    stubInstance.foo(123);
+                });
+            });
+
+            it('should fail with a diff', function () {
+                var stubInstance = sinon.createStubInstance(MyClass);
+                stubInstance.foo(123);
+                stubInstance.bar(456);
+                stubInstance.foo(123);
+                return expect(function () {
+                    return expect(stubInstance, 'to have all calls satisfying', function () {
+                        stubInstance.bar(456);
+                    });
+                }, 'to error with',
+                    "expected MyClass({foo, bar}) to have all calls satisfying bar( 456 );\n" +
+                    "\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy) // should be bar( 456 );\n" +
+                    "bar( 456 ); at theFunction (theFileName:xx:yy)\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy) // should be bar( 456 );"
+                );
+            });
+        });
+
         describe('when passed a spec object', function () {
             it('should succeed when a spy call satisfies the spec', function () {
                 spy(123, 456);
@@ -1485,6 +1584,45 @@ describe('unexpected-sinon', function () {
                 "└── spy2( 'yadda' ); at theFunction (theFileName:xx:yy) // should be moved\n" +
                 "    spy1( 'baz' ); at theFunction (theFileName:xx:yy)"
             );
+        });
+
+        describe('when passed a sinon stub instance as the subject', function () {
+            it('should succeed', function () {
+                var stubInstance = sinon.createStubInstance(MyClass);
+                stubInstance.foo(123);
+                stubInstance.bar(456);
+                stubInstance.foo(789);
+                return expect(stubInstance, 'to have calls satisfying', function () {
+                    stubInstance.foo(123);
+                    stubInstance.bar(456);
+                    stubInstance.foo(789);
+                });
+            });
+
+            it('should fail with a diff', function () {
+                var stubInstance = sinon.createStubInstance(MyClass);
+                stubInstance.foo(123);
+                stubInstance.bar(456);
+                stubInstance.foo(123);
+                return expect(function () {
+                    return expect(stubInstance, 'to have calls satisfying', function () {
+                        stubInstance.foo(123);
+                        stubInstance.bar(123);
+                        stubInstance.foo(123);
+                    });
+                }, 'to error with',
+                    "expected MyClass({foo, bar}) to have calls satisfying\n" +
+                    "foo( 123 );\n" +
+                    "bar( 123 );\n" +
+                    "foo( 123 );\n" +
+                    "\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy)\n" +
+                    "bar(\n" +
+                    "  456 // should equal 123\n" +
+                    "); at theFunction (theFileName:xx:yy)\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy)"
+                );
+            });
         });
 
         describe('when passed an array entry (shorthand for {args: ...})', function () {

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -588,6 +588,35 @@ describe('unexpected-sinon', function () {
             });
         });
 
+        describe('when passed an array of sinon stub instances as the subject', function () {
+            it('should succeed', function () {
+                var stubInstance1 = sinon.createStubInstance(MyClass);
+                stubInstance1.foo(123);
+                var stubInstance2 = sinon.createStubInstance(MyClass);
+                stubInstance2.foo(123);
+                return expect([stubInstance1, stubInstance2], 'to have no calls satisfying', function () {
+                    stubInstance1.foo(456);
+                });
+            });
+
+            it('should fail with a diff', function () {
+                var stubInstance1 = sinon.createStubInstance(MyClass);
+                stubInstance1.foo(123);
+                var stubInstance2 = sinon.createStubInstance(MyClass);
+                stubInstance2.foo(123);
+                return expect(function () {
+                    return expect([stubInstance1, stubInstance2], 'to have no calls satisfying', function () {
+                        stubInstance1.foo(123);
+                    });
+                }, 'to error with',
+                    "expected [ MyClass({ foo: foo, bar: bar }), MyClass({ foo: foo, bar: bar }) ] to have no calls satisfying foo( 123 );\n" +
+                    "\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy)\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy) // should be removed"
+                );
+            });
+        });
+
         describe('when passed a spec object', function () {
             it('should succeed when no spy call satisfies the spec', function () {
                 spy(123, 456);

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -577,14 +577,6 @@ describe('unexpected-sinon', function () {
                     "foo( 123 ); at theFunction (theFileName:xx:yy)"
                 );
             });
-
-            it('should throw if the stub instance (indistinguishable from a regular object) does not hold any spies', function () {
-                return expect(function () {
-                    return expect({}, 'to have no calls satisfying', function () {});
-                }, 'to error with',
-                    'The passed object was not recognized as a sinon "stub instance" as it has no spies attached to it:\n\n{}'
-                );
-            });
         });
 
         describe('when passed an array of sinon stub instances as the subject', function () {

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -609,7 +609,12 @@ describe('unexpected-sinon', function () {
                         stubInstance1.foo(123);
                     });
                 }, 'to error with',
-                    "expected [ MyClass({ foo: foo, bar: bar }), MyClass({ foo: foo, bar: bar }) ] to have no calls satisfying foo( 123 );\n" +
+                    "expected\n" +
+                    "[\n" +
+                    "  MyClass({ foo, bar }),\n" +
+                    "  MyClass({ foo, bar })\n" +
+                    "]\n" +
+                    "to have no calls satisfying foo( 123 );\n" +
                     "\n" +
                     "foo( 123 ); at theFunction (theFileName:xx:yy)\n" +
                     "foo( 123 ); at theFunction (theFileName:xx:yy) // should be removed"

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -291,7 +291,7 @@ describe('unexpected-sinon', function () {
                 "\n" +
                 "agent005(); at theFunction (theFileName:xx:yy)\n" +
                 "agent006(); at theFunction (theFileName:xx:yy)\n" +
-                "// missing { spy: agent007 }"
+                "// missing { agent007 }"
             );
         });
 
@@ -304,9 +304,9 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected [ agent005, agent006, agent007 ] given call order\n" +
                 "\n" +
-                "// missing { spy: agent005 }\n" +
-                "// missing { spy: agent006 }\n" +
-                "// missing { spy: agent007 }"
+                "// missing { agent005 }\n" +
+                "// missing { agent006 }\n" +
+                "// missing { agent007 }"
             );
         });
     });
@@ -350,12 +350,11 @@ describe('unexpected-sinon', function () {
                 obj.spy.call(null);
                 expect(obj.spy, 'was always called on', obj);
             }, 'to throw exception',
-                "expected spy1 was always called on { spy: spy1 }\n" +
+                "expected spy1 was always called on { spy1 }\n" +
                 "\n" +
                 "spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "// expected: was called on { spy: spy1 }\n" +
-                "//   expected spy1 to be called with { spy: spy1 } as this but was called with null"
+                "spy1(); at theFunction (theFileName:xx:yy) // expected: was called on { spy1 }\n" +
+                "                                           //   expected spy1 to be called with { spy1 } as this but was called with null"
             );
         });
     });
@@ -1583,7 +1582,7 @@ describe('unexpected-sinon', function () {
             expect(function () {
                 expect([spy1, spy2], 'to have calls satisfying', [ { spy: spy2 } ]);
             }, 'to throw',
-                "expected [ spy1, spy2 ] to have calls satisfying [ { spy: spy2 } ]\n" +
+                "expected [ spy1, spy2 ] to have calls satisfying [ { spy2 } ]\n" +
                 "\n" +
                 "spy1( 123 ); at theFunction (theFileName:xx:yy) // should be spy2"
             );

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -609,12 +609,7 @@ describe('unexpected-sinon', function () {
                         stubInstance1.foo(123);
                     });
                 }, 'to error with',
-                    "expected\n" +
-                    "[\n" +
-                    "  MyClass({ foo, bar }),\n" +
-                    "  MyClass({ foo, bar })\n" +
-                    "]\n" +
-                    "to have no calls satisfying foo( 123 );\n" +
+                    "expected [ MyClass({ foo: foo, bar: bar }), MyClass({ foo: foo, bar: bar }) ] to have no calls satisfying foo( 123 );\n" +
                     "\n" +
                     "foo( 123 ); at theFunction (theFileName:xx:yy)\n" +
                     "foo( 123 ); at theFunction (theFileName:xx:yy) // should be removed"

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -578,6 +578,14 @@ describe('unexpected-sinon', function () {
                     "foo( 123 ); at theFunction (theFileName:xx:yy)"
                 );
             });
+
+            it('should throw if the stub instance (indistinguishable from a regular object) does not hold any spies', function () {
+                return expect(function () {
+                    return expect({}, 'to have no calls satisfying', function () {});
+                }, 'to error with',
+                    'The passed object was not recognized as a sinon "stub instance" as it has no spies attached to it:\n\n{}'
+                );
+            });
         });
 
         describe('when passed a spec object', function () {

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -609,7 +609,7 @@ describe('unexpected-sinon', function () {
                         stubInstance1.foo(123);
                     });
                 }, 'to error with',
-                    "expected [ MyClass({ foo: foo, bar: bar }), MyClass({ foo: foo, bar: bar }) ] to have no calls satisfying foo( 123 );\n" +
+                    "expected [ MyClass({ foo, bar }), MyClass({ foo, bar }) ] to have no calls satisfying foo( 123 );\n" +
                     "\n" +
                     "foo( 123 ); at theFunction (theFileName:xx:yy)\n" +
                     "foo( 123 ); at theFunction (theFileName:xx:yy) // should be removed"

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -291,7 +291,7 @@ describe('unexpected-sinon', function () {
                 "\n" +
                 "agent005(); at theFunction (theFileName:xx:yy)\n" +
                 "agent006(); at theFunction (theFileName:xx:yy)\n" +
-                "// missing { agent007 }"
+                "// missing { spy: agent007 }"
             );
         });
 
@@ -304,9 +304,9 @@ describe('unexpected-sinon', function () {
             }, 'to throw exception',
                 "expected [ agent005, agent006, agent007 ] given call order\n" +
                 "\n" +
-                "// missing { agent005 }\n" +
-                "// missing { agent006 }\n" +
-                "// missing { agent007 }"
+                "// missing { spy: agent005 }\n" +
+                "// missing { spy: agent006 }\n" +
+                "// missing { spy: agent007 }"
             );
         });
     });
@@ -350,11 +350,12 @@ describe('unexpected-sinon', function () {
                 obj.spy.call(null);
                 expect(obj.spy, 'was always called on', obj);
             }, 'to throw exception',
-                "expected spy1 was always called on { spy1 }\n" +
+                "expected spy1 was always called on { spy: spy1 }\n" +
                 "\n" +
                 "spy1(); at theFunction (theFileName:xx:yy)\n" +
-                "spy1(); at theFunction (theFileName:xx:yy) // expected: was called on { spy1 }\n" +
-                "                                           //   expected spy1 to be called with { spy1 } as this but was called with null"
+                "spy1(); at theFunction (theFileName:xx:yy)\n" +
+                "// expected: was called on { spy: spy1 }\n" +
+                "//   expected spy1 to be called with { spy: spy1 } as this but was called with null"
             );
         });
     });
@@ -1574,7 +1575,7 @@ describe('unexpected-sinon', function () {
             expect(function () {
                 expect([spy1, spy2], 'to have calls satisfying', [ { spy: spy2 } ]);
             }, 'to throw',
-                "expected [ spy1, spy2 ] to have calls satisfying [ { spy2 } ]\n" +
+                "expected [ spy1, spy2 ] to have calls satisfying [ { spy: spy2 } ]\n" +
                 "\n" +
                 "spy1( 123 ); at theFunction (theFileName:xx:yy) // should be spy2"
             );

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -558,6 +558,26 @@ describe('unexpected-sinon', function () {
                     "foo( 123 ); at theFunction (theFileName:xx:yy)"
                 );
             });
+
+            it('should dot out the list of contained spies when they exceed expect.output.preferredWidth', function () {
+                expect.output.preferredWidth = 45;
+                var stubInstance = sinon.createStubInstance(MyClass);
+                stubInstance.foo(123);
+                stubInstance.bar(456);
+                stubInstance.foo(123);
+                return expect(function () {
+                    return expect(stubInstance, 'to have no calls satisfying', function () {
+                        stubInstance.bar(456);
+                    });
+                }, 'to error with',
+                    "expected MyClass({foo /* 1 more */})\n" +
+                    "to have no calls satisfying bar( 456 );\n" +
+                    "\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy)\n" +
+                    "bar( 456 ); at theFunction (theFileName:xx:yy) // should be removed\n" +
+                    "foo( 123 ); at theFunction (theFileName:xx:yy)"
+                );
+            });
         });
 
         describe('when passed a spec object', function () {

--- a/test/unexpected-sinon.spec.js
+++ b/test/unexpected-sinon.spec.js
@@ -551,7 +551,7 @@ describe('unexpected-sinon', function () {
                         stubInstance.bar(456);
                     });
                 }, 'to error with',
-                    "expected MyClass({foo, bar}) to have no calls satisfying bar( 456 );\n" +
+                    "expected MyClass({ foo, bar }) to have no calls satisfying bar( 456 );\n" +
                     "\n" +
                     "foo( 123 ); at theFunction (theFileName:xx:yy)\n" +
                     "bar( 456 ); at theFunction (theFileName:xx:yy) // should be removed\n" +
@@ -570,7 +570,7 @@ describe('unexpected-sinon', function () {
                         stubInstance.bar(456);
                     });
                 }, 'to error with',
-                    "expected MyClass({foo /* 1 more */})\n" +
+                    "expected MyClass({ foo /* 1 more */ })\n" +
                     "to have no calls satisfying bar( 456 );\n" +
                     "\n" +
                     "foo( 123 ); at theFunction (theFileName:xx:yy)\n" +
@@ -996,7 +996,7 @@ describe('unexpected-sinon', function () {
                         stubInstance.bar(789);
                     });
                 }, 'to error with',
-                    "expected MyClass({foo, bar}) to have a call satisfying bar( 789 );\n" +
+                    "expected MyClass({ foo, bar }) to have a call satisfying bar( 789 );\n" +
                     "\n" +
                     "foo( 123 ); at theFunction (theFileName:xx:yy) // should be bar( 789 );\n" +
                     "bar(\n" +
@@ -1255,7 +1255,7 @@ describe('unexpected-sinon', function () {
                         stubInstance.bar(456);
                     });
                 }, 'to error with',
-                    "expected MyClass({foo, bar}) to have all calls satisfying bar( 456 );\n" +
+                    "expected MyClass({ foo, bar }) to have all calls satisfying bar( 456 );\n" +
                     "\n" +
                     "foo( 123 ); at theFunction (theFileName:xx:yy) // should be bar( 456 );\n" +
                     "bar( 456 ); at theFunction (theFileName:xx:yy)\n" +
@@ -1639,7 +1639,7 @@ describe('unexpected-sinon', function () {
                         stubInstance.foo(123);
                     });
                 }, 'to error with',
-                    "expected MyClass({foo, bar}) to have calls satisfying\n" +
+                    "expected MyClass({ foo, bar }) to have calls satisfying\n" +
                     "foo( 123 );\n" +
                     "bar( 123 );\n" +
                     "foo( 123 );\n" +


### PR DESCRIPTION
(or any object that has spies as direct or prototypal properties).

Applies to these assertions:

* `to have calls [exhaustively] satisfying`
* `to have a call [exhaustively] satisfying`
* `to have no calls [exhaustively] satisfying`

Gathers all spies attached to the object and asserts on the complete timeline.

I would really have liked to handle this case by adding a `sinonStubInstance` type, but it seems like the objects returned by `sinon.createStubInstance(Constructor)` have no special characteristics, except that all their properties have values that are recognized as spies -- and that's probably by design.

Adding the `sinonStubInstance` type with an `identify` function that essentially goes `return obj && typeof obj === 'object' && Object.keys(obj).every(key => isSpy(obj[key]))` would probably be quite slow, and it also has false positives affecting other unexpected-sinon assertions that accept eg. `{ spy: <spyInstance> }` in RHS objects.