### PR TITLE
Return an "onCall(n)" object when invoking a spy from a function specifying the expected timeline.

### DIFF
--- a/lib/unexpected-sinon.js
+++ b/lib/unexpected-sinon.js
@@ -98,9 +98,14 @@
             // Temporarily override the body of the spied-on function, if any.
             // This prevents spies with side effects from breaking while
             // the expected calls are being recorded:
-            spy.func = function () {};
+            var callCount = spy.callCount;
+            spy.func = function () {
+                var onCall = spy.onCall && spy.onCall(callCount);
+                callCount += 1;
+                return onCall;
+            };
             for (var propertyName in spy) {
-                if (spy.hasOwnProperty(propertyName) && typeof spy[propertyName] !== 'function') {
+                if (spy.hasOwnProperty(propertyName) && propertyName !== 'behaviors' && typeof spy[propertyName] !== 'function') {
                     if (Array.isArray(spy[propertyName])) {
                         originalValue[propertyName] = [].concat(spy[propertyName]);
                     } else {


### PR DESCRIPTION
Makes it possible to chain behaviors (.returns/.yields/...) onto the function call.

Also, don't reset the "behaviors" property of the spy to the previous
value so behaviors added during the function don't get nuked.

Affects: `to have (a call|calls|no calls|all calls) [exhaustively] satisfying <function>`

This is not really useful yet, but I'm working on a new feature that will allow you to specify expected spy calls, expected parameters, mocked return values, and call order in one go, and this is a prereq. Also, it doesn't really do any harm.